### PR TITLE
Fix Customer#password2 field name.

### DIFF
--- a/lib/netsuite/records/customer.rb
+++ b/lib/netsuite/records/customer.rb
@@ -18,7 +18,7 @@ module NetSuite
         :group_pricing_list, :home_phone, :image, :is_budget_approved, :is_inactive, :is_person, :item_pricing_list, :keywords,
         :language, :last_modified_date, :last_name, :last_page_visited, :last_visit, :lead_source, :middle_name, :mobile_phone,
         :opening_balance, :opening_balance_account, :opening_balance_date, :parent, :partners_list,
-        :password, :password_2, :phone, :phonetic_name, :pref_cc_processor, :price_level, :print_on_check_as,
+        :password, :password2, :phone, :phonetic_name, :pref_cc_processor, :price_level, :print_on_check_as,
         :print_transactions, :referrer, :reminder_days, :representing_subsidiary, :require_pwd_change, :resale_number,
         :sales_group, :sales_readiness, :sales_rep, :sales_team_list, :salutation, :send_email, :ship_complete, :shipping_item,
         :stage, :start_date, :subscriptions_list, :subsidiary, :sync_partner_teams, :tax_exempt, :tax_item, :taxable, :terms,

--- a/spec/netsuite/records/customer_spec.rb
+++ b/spec/netsuite/records/customer_spec.rb
@@ -15,7 +15,7 @@ describe NetSuite::Records::Customer do
       :group_pricing_list, :home_phone, :image, :is_budget_approved, :is_inactive, :is_person, :item_pricing_list, :keywords,
       :language, :last_modified, :last_name, :last_page_visited, :last_visit, :lead_source, :middle_name, :mobile_phone,
       :opening_balance, :opening_balance_account, :opening_balance_date, :overdue_balance, :parent, :partners_list,
-      :password, :password_2, :phone, :phonetic_name, :pref_cc_processor, :price_level, :print_on_check_as,
+      :password, :password2, :phone, :phonetic_name, :pref_cc_processor, :price_level, :print_on_check_as,
       :print_transactions, :referrer, :reminder_days, :representing_subsidiary, :require_pwd_change, :resale_number,
       :sales_group, :sales_readiness, :sales_rep, :sales_team_list, :salutation, :send_email, :ship_complete, :shipping_item,
       :stage, :start_date, :subscriptions_list, :subsidiary, :sync_partner_teams, :tax_exempt, :tax_item, :taxable, :terms,


### PR DESCRIPTION
It looks like there's a typo in Customer. It seems to need "password2" instead of "password_2". It appears to be this way in the [2011](https://webservices.sandbox.netsuite.com/xsd/lists/v2011_1_0/relationships.xsd), [2012](https://webservices.sandbox.netsuite.com/xsd/lists/v2012_1_0/relationships.xsd), and [2013](https://webservices.sandbox.netsuite.com/xsd/lists/v2013_1_0/relationships.xsd) wsdls.

It fails if you try to set "password_2" and works like a charm if you use "password2".
