### PR TITLE
Fix search preferences configs

### DIFF
--- a/lib/netsuite/actions/search.rb
+++ b/lib/netsuite/actions/search.rb
@@ -20,10 +20,9 @@ module NetSuite
       def request
         # https://system.netsuite.com/help/helpcenter/en_US/Output/Help/SuiteCloudCustomizationScriptingWebServices/SuiteTalkWebServices/SettingSearchPreferences.html
         # https://webservices.netsuite.com/xsd/platform/v2012_2_0/messages.xsd
-
         preferences = NetSuite::Configuration.auth_header
         preferences = preferences.merge(
-          (@options[:preferences] || {}).inject({'platformMsgs:SearchPreferences' => {}}) do |h, (k, v)|
+          (@options.delete(:preferences) || {}).inject({'platformMsgs:SearchPreferences' => {}}) do |h, (k, v)|
             h['platformMsgs:SearchPreferences'][k.to_s.lower_camelcase] = v
             h
           end

--- a/spec/netsuite/actions/search_spec.rb
+++ b/spec/netsuite/actions/search_spec.rb
@@ -17,7 +17,7 @@ describe NetSuite::Actions::Search do
   end
 
   context "saved search" do
-    it "should handle a ID only search" do
+    before do
       savon.expects(:search).with(:message => {
         'searchRecord' => {
           '@xsi:type'           => 'listRel:CustomerSearchAdvanced',
@@ -25,10 +25,21 @@ describe NetSuite::Actions::Search do
           :content!             => { "listRel:criteria" => {} }
         },
       }).returns(File.read('spec/support/fixtures/search/saved_search_customer.xml'))
+    end
 
+    it "should handle a ID only search" do
       result = NetSuite::Records::Customer.search(saved: 500)
       result.results.size.should == 1
       result.results.first.email.should == 'aemail@gmail.com'
+    end
+
+    it "merges preferences gracefully" do
+      expect {
+          NetSuite::Records::Customer.search(
+            saved: 500,
+            preferences: { page_size: 20 }
+          )
+      }.not_to raise_error
     end
 
     pending "should handle a ID search with basic params"


### PR DESCRIPTION
The Search class was looping through the `@options` hash without noticing
that it contains the SearchPreferences config as well. That gave an
error of:

```
TypeError:
  no implicit conversion of Symbol into Integer
# ./lib/netsuite/actions/search.rb:76:in `[]'
```

I think the gem could offer a more reasonable default for page_size, NetSuite defaults to 1000 which looks like a pretty crazy value. What you guys think?

ps. I have no idea why github shows me an "Error checking merge status". It should merge cleanly. Let me know if I missed something please.
