### PR TITLE
Corrrected 'other_ref_name' field to 'other_ref_num' on Invoice object

### DIFF
--- a/lib/netsuite/records/invoice.rb
+++ b/lib/netsuite/records/invoice.rb
@@ -20,7 +20,7 @@ module NetSuite
         :item_cost_disc_rate, :item_cost_disc_tax_1_amt, :item_cost_disc_taxable, :item_cost_discount, :item_cost_list,
         :item_cost_tax_code, :item_cost_tax_rate_1, :item_cost_tax_rate_2, :item_list, :job, :last_modified_date,
         :lead_source, :linked_tracking_numbers, :memo, :message, :message_sel, :on_credit_hold, :opportunity,
-        :other_ref_name, :partners_list, :promo_code, :rev_rec_end_date,
+        :other_ref_num, :partners_list, :promo_code, :rev_rec_end_date,
         :rev_rec_on_rev_commitment, :rev_rec_schedule, :rev_rec_start_date, :revenue_status, :sales_effective_date,
         :sales_group, :sales_team_list, :ship_address, :ship_date, :ship_group_list,
         :shipping_cost, :shipping_tax_1_rate, :shipping_tax_2_rate, :shipping_tax_code, :source, :start_date,

--- a/spec/netsuite/records/invoice_spec.rb
+++ b/spec/netsuite/records/invoice_spec.rb
@@ -18,7 +18,7 @@ describe NetSuite::Records::Invoice do
       :item_cost_disc_rate, :item_cost_disc_tax_1_amt, :item_cost_disc_taxable, :item_cost_discount, :item_cost_list,
       :item_cost_tax_code, :item_cost_tax_rate_1, :item_cost_tax_rate_2, :job, :last_modified_date,
       :lead_source, :linked_tracking_numbers, :memo, :message, :message_sel, :on_credit_hold, :opportunity,
-      :other_ref_name, :partners_list, :promo_code, :rev_rec_end_date,
+      :other_ref_num, :partners_list, :promo_code, :rev_rec_end_date,
       :rev_rec_on_rev_commitment, :rev_rec_schedule, :rev_rec_start_date, :revenue_status, :sales_effective_date,
       :sales_group, :sales_team_list, :ship_address, :ship_date, :ship_group_list,
       :shipping_cost, :shipping_tax_1_rate, :shipping_tax_2_rate, :shipping_tax_code, :source, :start_date,


### PR DESCRIPTION
Hello, 

Please pull my changes.  I have a project that depends on populating the field "other_ref_num" on the Invoice object.  I used the changed code, and I was able to successfully populate the field.  I ran the test suite, and the change didn't break any specs.  

If you'd like a reference to the other "otherRefNum" field on the Invoice object, it can be found in this wsdl file here:
https://webservices.netsuite.com/xsd/transactions/v2013_2_0/sales.xsd

Thank you!
