### PR TITLE
Add update to action to InventoryItem plus NOTE on search

### DIFF
--- a/lib/netsuite/records/inventory_item.rb
+++ b/lib/netsuite/records/inventory_item.rb
@@ -51,7 +51,7 @@ module NetSuite
         :parent, :preferred_location, :pricing_group, :purchase_price_variance_acct, :purchase_tax_code, :purchase_unit,
         :quantity_pricing_schedule, :rev_rec_schedule, :sale_unit, :sales_tax_code, :ship_package, :soft_descriptor,
         :stock_unit, :store_display_image, :store_display_thumbnail, :store_item_template, :supply_lot_sizing_method,
-        :supply_replenishment_method, :supply_type, :tax_schedule, :units_type, :vendor
+        :supply_replenishment_method, :supply_type, :tax_schedule, :units_type, :vendor, :locations_list
 
       field :pricing_matrix, PricingMatrix
       field :custom_field_list, CustomFieldList


### PR DESCRIPTION
Added the comment on inventory item search hoping that it would save someone time when working on it. Ideally NetSuite gem could have a Item object as well which InventoryItem inherit from and add that type filter as default on search calls. That should be an interesting refactoring exercise (except for the xml part). I might give it a try later on.
