### PR TITLE
Improve locations_list accessor a little bit

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -91,6 +91,7 @@ module NetSuite
     autoload :JournalEntryLineList,       'netsuite/records/journal_entry_line_list'
     autoload :KitItem,                    'netsuite/records/kit_item'
     autoload :Location,                   'netsuite/records/location'
+    autoload :LocationsList,              'netsuite/records/locations_list'
     autoload :NonInventorySaleItem,       'netsuite/records/non_inventory_sale_item'
     autoload :PaymentMethod,              'netsuite/records/payment_method'
     autoload :PhoneCall,                  'netsuite/records/phone_call'

--- a/lib/netsuite/records/inventory_item.rb
+++ b/lib/netsuite/records/inventory_item.rb
@@ -51,12 +51,12 @@ module NetSuite
         :parent, :preferred_location, :pricing_group, :purchase_price_variance_acct, :purchase_tax_code, :purchase_unit,
         :quantity_pricing_schedule, :rev_rec_schedule, :sale_unit, :sales_tax_code, :ship_package, :soft_descriptor,
         :stock_unit, :store_display_image, :store_display_thumbnail, :store_item_template, :supply_lot_sizing_method,
-        :supply_replenishment_method, :supply_type, :tax_schedule, :units_type, :vendor, :locations_list
+        :supply_replenishment_method, :supply_type, :tax_schedule, :units_type, :vendor
 
       field :pricing_matrix, PricingMatrix
       field :custom_field_list, CustomFieldList
       field :bin_number_list, BinNumberList
-      field :pricing_matrix, PricingMatrix
+      field :locations_list, LocationsList
       
       attr_reader :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/locations_list.rb
+++ b/lib/netsuite/records/locations_list.rb
@@ -1,0 +1,15 @@
+module NetSuite
+  module Records
+    class LocationsList
+      def initialize(attributes = {})
+        attributes[:locations].each do |location|
+          locations << location
+        end if attributes[:locations]
+      end
+
+      def locations
+        @locations ||= []
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey guys this a follow up of https://github.com/RevolutionPrep/netsuite/commit/223b2481c00f18a9cc138956850865562a5c3242. I didn't mean to push that commit at the time sorry. This still doesn't look ideal but helps a bit to access the locations list. We can do `item.locations_list.locations` instead of `items.locations_list.attributes[:locations]`. Just like it's already done with the PricingMatrix example.

Ideally I'd love to get the locations_list with only `item.locations_list`. But I think I might have to change a bit more code on Actions::Search.
