### PR TITLE
fix for to_record ItemFulfillmentPackageList

### DIFF
--- a/lib/netsuite/records/item_fulfillment_package_list.rb
+++ b/lib/netsuite/records/item_fulfillment_package_list.rb
@@ -46,7 +46,7 @@ module NetSuite
       end
 
       def to_record
-        { "#{record_namespace}:package" => items.map(&:to_record) }
+        { "#{record_namespace}:package" => packages.map(&:to_record) }
       end
     end
   end

--- a/spec/netsuite/records/item_fulfillment_package_list_spec.rb
+++ b/spec/netsuite/records/item_fulfillment_package_list_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe NetSuite::Records::ItemFulfillmentPackageList do
+  let(:list) { NetSuite::Records::ItemFulfillmentPackageList.new }
+
+  it 'has a packages attribute' do
+    list.packages.should be_kind_of(Array)
+  end
+
+  describe '#to_record' do
+    before do
+      list.packages << NetSuite::Records::ItemFulfillmentPackage.new(
+        :package_tracking_number => '1Z12354645757686786'
+      )
+    end
+
+    it 'can represent itself as a SOAP record' do
+      record = {
+          'tranSales:package' => [
+            'tranSales:packageTrackingNumber' => '1Z12354645757686786'
+          ]
+        }
+      
+      list.to_record.should eql(record)
+    end
+  end
+end


### PR DESCRIPTION
Fixed copy/paste error in #to_record. The fix will now allow you to create an ItemFulfillmentPackageList.
