### PR TITLE
add option to silence logging entirely

### DIFF
--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -19,6 +19,7 @@ module NetSuite
         pretty_print_xml: true,
         logger: logger,
         log_level: log_level,
+        log: !silent,   # turn off logging entirely if configured
       }.update(params))
     end
 
@@ -174,6 +175,15 @@ module NetSuite
       else
         value
       end
+    end
+
+    def silent(value=nil)
+      self.silent = value if value
+      attributes[:silent]
+    end
+
+    def silent=(value)
+      attributes[:silent] ||= value
     end
 
     def log_level(value = nil)


### PR DESCRIPTION
This allows you to turn off both Savon and HTTPI output.

usage:

```
NetSuite.configure do
  reset!
  # etc
  silent true
end
```
