### PR TITLE
Use :klass to prevent over-writing class variable

### DIFF
--- a/lib/netsuite/records/deposit_cash_back.rb
+++ b/lib/netsuite/records/deposit_cash_back.rb
@@ -15,7 +15,7 @@ module NetSuite
 
       fields :amount, :memo
 
-      record_refs :account, :department, :class, :location
+      record_refs :account, :department, :klass, :location
 
       def initialize(attributes_or_record = {})
         case attributes_or_record

--- a/lib/netsuite/records/deposit_other.rb
+++ b/lib/netsuite/records/deposit_other.rb
@@ -18,7 +18,7 @@ module NetSuite
 
       fields :amount, :ref_num, :memo
 
-      record_refs :entity, :account, :payment_method, :department, :class, :location
+      record_refs :entity, :account, :payment_method, :department, :klass, :location
 
       def initialize(attributes_or_record = {})
         case attributes_or_record

--- a/spec/netsuite/records/deposit_spec.rb
+++ b/spec/netsuite/records/deposit_spec.rb
@@ -42,6 +42,24 @@ describe NetSuite::Records::Deposit do
     end
   end
 
+  describe '#cash_back_list' do
+    it 'can be set from attributes' do
+      attributes = {
+        amount: 100,
+        memo: "test"
+      }
+      deposit.cash_back_list.cashback = attributes
+      deposit.cash_back_list.should be_kind_of(NetSuite::Records::DepositCashBackList)
+      deposit.cash_back_list.cashbacks.length.should eql(1)
+    end
+
+    it 'can be set from a DepositCashBackList object' do
+      item_list = NetSuite::Records::DepositCashBackList.new
+      deposit.cash_back_list = item_list
+      deposit.cash_back_list.should eql(item_list)
+    end
+  end
+
   describe '.get' do
     context 'when the response is successful' do
       let(:response) { NetSuite::Response.new(:success => true, :body => { :memo => 'transfer for subscriptions' }) }


### PR DESCRIPTION
Allow cash backs to be created on deposits. Also apply the fix to the DepositOther class.

Fixes #92
