### PR TITLE
Add support for custom soap headers

### DIFF
--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -15,7 +15,7 @@ module NetSuite
         wsdl: wsdl,
         read_timeout: read_timeout,
         namespaces: namespaces,
-        soap_header: auth_header(credentials),
+        soap_header: auth_header(credentials).update(soap_header),
         pretty_print_xml: true,
         logger: logger,
         log_level: log_level,
@@ -63,6 +63,18 @@ module NetSuite
         end
 
         attributes[:wsdl] ||= wsdl_path
+      end
+    end
+
+    def soap_header=(headers)
+      attributes[:soap_header] = headers
+    end
+
+    def soap_header(headers = nil)
+      if headers
+        self.soap_header = headers
+      else
+        attributes[:soap_header] ||= {}
       end
     end
 

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -72,6 +72,27 @@ describe NetSuite::Configuration do
     end
   end
 
+  describe '#soap_header' do
+    before do
+      config.email    = 'user@example.com'
+      config.password = 'myPassword'
+      config.account  = 1234
+    end
+
+    it 'adds a new header to the soap header' do
+      config.soap_header = {
+        'platformMsgs:preferences' => {
+          'platformMsgs:ignoreReadOnlyFields' => true,
+        }
+      }
+      config.soap_header.should eql({
+        'platformMsgs:preferences' => {
+          'platformMsgs:ignoreReadOnlyFields' => true,
+        }
+      })
+    end
+  end
+
   describe '#email' do
     context 'when the email has been set' do
       before do


### PR DESCRIPTION
This change allows you to set soap headers on the client outside of authentication headers.

This is a cleaned up version of #86 
