### PR TITLE
Fix for credit, payment and refund apply lists not working

### DIFF
--- a/lib/netsuite/records/credit_memo_apply_list.rb
+++ b/lib/netsuite/records/credit_memo_apply_list.rb
@@ -16,10 +16,12 @@ module NetSuite
         @applies ||= []
       end
 
-      def to_record
-        applies.map do |apply|
-          { "#{record_namespace}:apply" => apply.to_record }
-        end
+       def to_record
+        [{ 
+          "#{record_namespace}:apply" => applies.map do |apply|
+            apply.to_record 
+          end
+        }]
       end
 
     end

--- a/lib/netsuite/records/customer_payment_apply_list.rb
+++ b/lib/netsuite/records/customer_payment_apply_list.rb
@@ -17,9 +17,11 @@ module NetSuite
       end
 
       def to_record
-        applies.map do |apply|
-          { "#{record_namespace}:apply" => apply.to_record }
-        end
+        [{ 
+          "#{record_namespace}:apply" => applies.map do |apply|
+            apply.to_record 
+          end
+        }]
       end
 
     end

--- a/lib/netsuite/records/customer_refund_apply_list.rb
+++ b/lib/netsuite/records/customer_refund_apply_list.rb
@@ -16,10 +16,12 @@ module NetSuite
         @applies ||= []
       end
 
-      def to_record
-        applies.map do |apply|
-          { "#{record_namespace}:apply" => apply.to_record }
-        end
+       def to_record
+        [{ 
+          "#{record_namespace}:apply" => applies.map do |apply|
+            apply.to_record 
+          end
+        }]
       end
 
     end

--- a/spec/netsuite/records/credit_memo_apply_list_spec.rb
+++ b/spec/netsuite/records/credit_memo_apply_list_spec.rb
@@ -17,9 +17,9 @@ describe NetSuite::Records::CreditMemoApplyList do
     it 'can represent itself as a SOAP record' do
       record = [
         {
-          'tranCust:apply' => {
+          'tranCust:apply' => [{
             'tranCust:job' => 'something'
-          }
+          }]
         }
       ]
       list.to_record.should eql(record)

--- a/spec/netsuite/records/customer_refund_apply_list_spec.rb
+++ b/spec/netsuite/records/customer_refund_apply_list_spec.rb
@@ -15,9 +15,9 @@ describe NetSuite::Records::CustomerRefundApplyList do
     it 'can represent itself as a SOAP record' do
       record = [
         {
-          'tranCust:apply' => {
+          'tranCust:apply' => [{
             'tranCust:amount' => 10
-          }
+          }]
         }
       ]
       list.to_record.should eql(record)


### PR DESCRIPTION
I found that with the existing `to_record` method, you could not apply a payment to multiple invoices. It would always only apply to the last one. 

After looking at the request I found it to be incorrectly constructing the apply list.

Currently it looks like this:

```
<tranCust:applyList>
	<tranCust:apply>
	 	<tranCust:doc>5760</tranCust:doc>
 		<tranCust:apply>true</tranCust:apply>
 		<tranCust:amount>12</tranCust:amount>
	</tranCust:apply>
</tranCust:applyList>
<tranCust:applyList>
	<tranCust:apply>
 		<tranCust:doc>5761</tranCust:doc>
 		<tranCust:apply>true</tranCust:apply>
 		<tranCust:amount>34</tranCust:amount>
 	</tranCust:apply>
</tranCust:applyList>
```

It should look like this:
```
<tranCust:applyList>
	<tranCust:apply>
	 	<tranCust:doc>5760</tranCust:doc>
 		<tranCust:apply>true</tranCust:apply>
 		<tranCust:amount>12</tranCust:amount>
	</tranCust:apply>
	<tranCust:apply>
 		<tranCust:doc>5761</tranCust:doc>
 		<tranCust:apply>true</tranCust:apply>
 		<tranCust:amount>34</tranCust:amount>
 	</tranCust:apply>
</tranCust:applyList>
```
