### PR TITLE
Make NonInventorySaleItems searchable

### DIFF
--- a/lib/netsuite/records/non_inventory_sale_item.rb
+++ b/lib/netsuite/records/non_inventory_sale_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :add, :delete
+      actions :get, :add, :delete, :search
 
       fields :available_to_partners, :cost_estimate, :cost_estimate_type, :cost_estimate_units, :country_of_manufacture,
         :created_date, :display_name, :dont_show_price, :enforce_min_qty_internally, :exclude_from_sitemap,
@@ -43,6 +43,9 @@ module NetSuite
         initialize_from_attributes_hash(attributes)
       end
 
+      def self.search_class_name
+        "Item"
+      end
     end
   end
 end


### PR DESCRIPTION
This is pretty straightforward. We need to search `NonInventorySaleItem`s. I've added the minimum needed (modeled after search on `InventoryItem`).
