### PR TITLE
Add WorkOrder record type

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -16,12 +16,12 @@ module NetSuite
     autoload :ListRel,        'netsuite/namespaces/list_rel'
     autoload :ListSupport,    'netsuite/namespaces/list_support'
     autoload :ListWebsite,    'netsuite/namespaces/list_website'
-    autoload :Inventory,      'netsuite/namespaces/inventory'
     autoload :PlatformCommon, 'netsuite/namespaces/platform_common'
     autoload :PlatformCore,   'netsuite/namespaces/platform_core'
     autoload :TranBank,       'netsuite/namespaces/tran_bank'
     autoload :TranCust,       'netsuite/namespaces/tran_cust'
     autoload :TranGeneral,    'netsuite/namespaces/tran_general'
+    autoload :TranInvt,       'netsuite/namespaces/tran_invt'
     autoload :TranSales,      'netsuite/namespaces/tran_sales'
     autoload :SetupCustom,    'netsuite/namespaces/setup_custom'
     autoload :ListMkt,        'netsuite/namespaces/list_mkt'
@@ -134,6 +134,8 @@ module NetSuite
     autoload :Term,                       'netsuite/records/term'
     autoload :Transaction,                'netsuite/records/transaction'
     autoload :WorkOrder,                  'netsuite/records/work_order'
+    autoload :WorkOrderItem,              'netsuite/records/work_order_item'
+    autoload :WorkOrderItemList,          'netsuite/records/work_order_item_list'
   end
 
   def self.configure(&block)

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -101,6 +101,7 @@ module NetSuite
         'xmlns:listAcct'       => "urn:accounting_#{api_version}.lists.webservices.netsuite.com",
         'xmlns:tranBank'       => "urn:bank_#{api_version}.transactions.webservices.netsuite.com",
         'xmlns:tranCust'       => "urn:customers_#{api_version}.transactions.webservices.netsuite.com",
+        'xmlns:tranInvt'       => "urn:inventory_#{api_version}.transactions.webservices.netsuite.com",
         'xmlns:listSupport'    => "urn:support_#{api_version}.lists.webservices.netsuite.com",
         'xmlns:tranGeneral'    => "urn:general_#{api_version}.transactions.webservices.netsuite.com",
         'xmlns:listMkt'        => "urn:marketing_#{api_version}.lists.webservices.netsuite.com",

--- a/lib/netsuite/namespaces/tran_invt.rb
+++ b/lib/netsuite/namespaces/tran_invt.rb
@@ -1,9 +1,11 @@
 module NetSuite
   module Namespaces
-    module Inventory
+    module TranInvt
+
       def record_namespace
-        'inventory'
+        'tranInvt'
       end
+
     end
   end
 end

--- a/lib/netsuite/records/work_order.rb
+++ b/lib/netsuite/records/work_order.rb
@@ -5,18 +5,19 @@ module NetSuite
       include Support::RecordRefs
       include Support::Records
       include Support::Actions
-      include Namespaces::Inventory
+      include Namespaces::TranInvt
 
       actions :get, :add, :initialize, :delete, :update, :upsert, :search
 
       fields :buildable, :built, :created_date, :end_date, :expanded_assembly,
-        :firmed, :is_wip, :item_list, :last_modified_date, :memo,
-        :order_status, :partners_list, :quantity, :sales_team_list,
-        :source_transaction_id, :source_transaction_line, :special_order,
-        :start_date, :status, :tran_date, :tran_id
+        :firmed, :is_wip, :last_modified_date, :memo, :order_status,
+        :partners_list, :quantity, :sales_team_list, :source_transaction_id,
+        :source_transaction_line, :special_order, :start_date, :status,
+        :tran_date, :tran_id
 
       field :custom_field_list, CustomFieldList
       field :options,           CustomFieldList
+      field :item_list,         WorkOrderItemList
 
       record_refs :assembly_item, :created_from, :custom_form,
         :department, :entity, :job, :location, :manufacturing_routing,

--- a/lib/netsuite/records/work_order_item.rb
+++ b/lib/netsuite/records/work_order_item.rb
@@ -1,0 +1,31 @@
+module NetSuite
+  module Records
+    class WorkOrderItem
+      include Support::Fields
+      include Support::RecordRefs
+      include Support::Records
+      include Namespaces::TranInvt
+
+      fields :average_cost, :bom_quantity, :commit, :component_yield,
+        :contribution, :create_po, :create_wo, :description, :inventory_detail,
+        :last_purchase_price, :line, :order_priority, :percent_complete,
+        :po_rate, :quantity, :quantity_available, :quantity_back_ordered,
+        :quantity_committed, :quantity_on_hand, :serial_numbers
+
+      field :custom_field_list, CustomFieldList
+      field :options,           CustomFieldList
+
+      record_refs :department, :item, :location, :po_vender, :units
+
+      attr_reader   :internal_id
+      attr_accessor :external_id
+      attr_accessor :search_joins
+
+      def initialize(attributes = {})
+        @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
+        @external_id = attributes.delete(:external_id) || attributes.delete(:@external_id)
+        initialize_from_attributes_hash(attributes)
+      end
+    end
+  end
+end

--- a/lib/netsuite/records/work_order_item_list.rb
+++ b/lib/netsuite/records/work_order_item_list.rb
@@ -1,0 +1,31 @@
+module NetSuite
+  module Records
+    class WorkOrderItemList
+      include Support::Fields
+      include Namespaces::TranInvt
+
+      fields :item
+
+      def initialize(attributes = {})
+        initialize_from_attributes_hash(attributes)
+      end
+
+      def item=(items)
+        case items
+        when Hash
+          self.items << WorkOrderItem.new(items)
+        when Array
+          items.each { |item| self.items << WorkOrderItem.new(item) }
+        end
+      end
+
+      def items
+        @items ||= []
+      end
+
+      def to_record
+        { "#{record_namespace}:item" => items.map(&:to_record) }
+      end
+    end
+  end
+end

--- a/spec/netsuite/records/work_order_item_list_spec.rb
+++ b/spec/netsuite/records/work_order_item_list_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe NetSuite::Records::WorkOrderItemList do
+  let(:list) { NetSuite::Records::WorkOrderItemList.new }
+
+  it 'has a items attribute' do
+    list.items.should be_kind_of(Array)
+  end
+
+  describe '#to_record' do
+    before do
+      list.items << NetSuite::Records::WorkOrderItem.new(
+        :average_cost => 10
+      )
+    end
+
+    it 'can represent itself as a SOAP record' do
+      record =  {
+        'tranInvt:item' => [{
+          'tranInvt:averageCost' => 10
+        }]
+      }
+      list.to_record.should eql(record)
+    end
+  end
+end

--- a/spec/netsuite/records/work_order_item_spec.rb
+++ b/spec/netsuite/records/work_order_item_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe NetSuite::Records::WorkOrderItem do
+  let(:work_order) { NetSuite::Records::WorkOrderItem.new }
+
+  [
+    :average_cost, :bom_quantity, :commit, :component_yield, :contribution,
+    :create_po, :create_wo, :description, :inventory_detail,
+    :last_purchase_price, :line, :order_priority, :percent_complete, :po_rate,
+    :quantity, :quantity_available, :quantity_back_ordered,
+    :quantity_committed, :quantity_on_hand, :serial_numbers
+  ].each do |field|
+    it "has the #{field} field" do
+      work_order.should have_field(field)
+    end
+  end
+
+  [
+    :department, :item, :location, :po_vender, :units
+  ].each do |record_ref|
+    it 'has the #{record_ref} record ref' do
+      expect(work_order).to have_record_ref(record_ref)
+    end
+  end
+
+  describe '#custom_field_list' do
+    it 'can be set from attributes' do
+      attributes = {
+        :custom_field => {
+          :value => 10,
+          :internal_id => 'custfield_something'
+        }
+      }
+      work_order.custom_field_list = attributes
+      work_order.custom_field_list.should be_kind_of(NetSuite::Records::CustomFieldList)
+      work_order.custom_field_list.custom_fields.length.should eql(1)
+    end
+
+    it 'can be set from a CustomFieldList object' do
+      custom_field_list = NetSuite::Records::CustomFieldList.new
+      work_order.custom_field_list = custom_field_list
+      work_order.custom_field_list.should eql(custom_field_list)
+    end
+  end
+end

--- a/spec/netsuite/records/work_order_spec.rb
+++ b/spec/netsuite/records/work_order_spec.rb
@@ -5,8 +5,8 @@ describe NetSuite::Records::WorkOrder do
 
   [
     :buildable, :built, :created_date, :end_date, :expanded_assembly, :firmed,
-    :is_wip, :item_list, :last_modified_date, :memo, :order_status,
-    :partners_list, :quantity, :sales_team_list, :source_transaction_id,
+    :is_wip, :last_modified_date, :memo, :order_status, :partners_list,
+    :quantity, :sales_team_list, :source_transaction_id,
     :source_transaction_line, :special_order, :start_date, :status, :tran_date,
     :tran_id
   ].each do |field|
@@ -42,6 +42,26 @@ describe NetSuite::Records::WorkOrder do
       custom_field_list = NetSuite::Records::CustomFieldList.new
       work_order.custom_field_list = custom_field_list
       work_order.custom_field_list.should eql(custom_field_list)
+    end
+  end
+
+  describe '#item_list' do
+    it 'can be set from attributes' do
+      attributes = {
+        item: {
+          :averageCost => 10,
+          :internal_id => 'itemAbc123'
+        }
+      }
+      work_order.item_list = attributes
+      work_order.item_list.should be_kind_of(NetSuite::Records::WorkOrderItemList)
+      work_order.item_list.items.length.should eql(1)
+    end
+
+    it 'can be set from a WorkOrderItemList object' do
+      order_item_list = NetSuite::Records::WorkOrderItemList.new
+      work_order.item_list = order_item_list
+      work_order.item_list.should eq(order_item_list)
     end
   end
 


### PR DESCRIPTION
Includes `WorkOrder`, `WorkOrderItemList` and `WorkOrderItem`

Full documentation:
https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2014_1/schema/record/workorder.html
