### PR TITLE
Custom field compatibility with 2013_2 @script_id tag.

### DIFF
--- a/lib/netsuite/records/custom_field.rb
+++ b/lib/netsuite/records/custom_field.rb
@@ -4,10 +4,12 @@ module NetSuite
       include Support::Fields
       include Support::Records
 
-      attr_reader :internal_id
+      attr_reader :internal_id,
+                  :script_id
       attr_accessor :type
 
       def initialize(attributes = {})
+        @script_id = attributes.delete(:script_id) || attributes.delete(:@script_id)
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
         @type        = attributes.delete(:type) || attributes.delete(:"@xsi:type")
         self.attributes = attributes

--- a/lib/netsuite/records/custom_field_list.rb
+++ b/lib/netsuite/records/custom_field_list.rb
@@ -12,7 +12,10 @@ module NetSuite
         end
         
         @custom_fields_assoc = Hash.new
-        custom_fields.each { |custom_field| @custom_fields_assoc[custom_field.internal_id.to_sym] = custom_field }
+        custom_fields.each do |custom_field|
+          reference_id = custom_field.script_id || custom_field.internal_id
+          @custom_fields_assoc[reference_id.to_sym] = custom_field
+        end
       end
 
       def custom_fields


### PR DESCRIPTION
If you use the 2012_1 wsdl, you can call a custom field on a customer like this:

``` ruby
customer.custom_field_list.custentity_example_field.value
```

When you change the wsdl to 2013_2, you will get undefined method custentity_example_field.  That is because the internal_id is now a numeric property and the old internal_id has been renamed to script_id.  This means that currently you have to get custom fields like this:

``` ruby
customer.custom_field_list.custom_fields.select { |cf| cf.attributes['@script_id'.to_sym] == 'custentity_example_field' }.value
# or
customer.custom_field_list.send('509').value
```

This pull request addresses the problem by first trying to use script_id and then internal_id when a field is referenced, which means you can reference the field normally with the 2013_2 wsdl.
