### PR TITLE
Customer address book addr_text needs to be a read-only field to prevent...

### DIFF
--- a/lib/netsuite/records/customer_addressbook.rb
+++ b/lib/netsuite/records/customer_addressbook.rb
@@ -6,7 +6,9 @@ module NetSuite
       include Namespaces::ListRel
 
       fields :default_shipping, :default_billing, :is_residential, :label, :attention, :addressee,
-        :phone, :addr1, :addr2, :addr3, :city, :zip, :country, :addr_text, :override, :state
+        :phone, :addr1, :addr2, :addr3, :city, :zip, :country, :override, :state
+
+      read_only_fields :addr_text
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/spec/netsuite/records/customer_addressbook_spec.rb
+++ b/spec/netsuite/records/customer_addressbook_spec.rb
@@ -30,6 +30,14 @@ describe NetSuite::Records::CustomerAddressbook do
     end
   end
 
+  it 'has all the right read_only_fields' do
+    [
+      :addr_text
+    ].each do |field|
+      NetSuite::Records::CustomerAddressbook.should have_read_only_field(field)
+    end
+  end
+
   describe '#initialize' do
     context 'when taking in a hash of attributes' do
       it 'sets the attributes for the object given the attributes hash' do
@@ -72,7 +80,6 @@ describe NetSuite::Records::CustomerAddressbook do
     it 'can represent itself as a SOAP record' do
       record = {
         'listRel:addr1'           => '123 Happy Lane',
-        'listRel:addrText'        => "123 Happy Lane\nLos Angeles CA 90007",
         'listRel:city'            => 'Los Angeles',
         'listRel:country'         => '_unitedStates',
         'listRel:defaultBilling'  => true,


### PR DESCRIPTION
This may be a consequence to the recent NetSuite Release 2014.2.

Customer address book addr_text needs to be a read-only field to prevent this NetSuite error - type: ERROR, code: INSUFFICIENT_PERMISSION, message: "You do not have permissions to set a value for element addrtext due to one of the following reasons: 1) The field is read-only; 2) An associated feature is disabled; 3) The field is available either when a record is created or updated, but not in both cases."
