### PR TITLE
Include scriptId in custom field list requests

### DIFF
--- a/lib/netsuite/records/custom_field.rb
+++ b/lib/netsuite/records/custom_field.rb
@@ -4,10 +4,11 @@ module NetSuite
       include Support::Fields
       include Support::Records
 
-      attr_reader :internal_id
+      attr_reader :internal_id, :script_id
       attr_accessor :type
 
       def initialize(attributes = {})
+        @script_id   = attributes.delete(:script_id) || attributes.delete(:@script_id)
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
         @type        = attributes.delete(:type) || attributes.delete(:"@xsi:type")
         self.attributes = attributes

--- a/lib/netsuite/records/custom_field_list.rb
+++ b/lib/netsuite/records/custom_field_list.rb
@@ -64,11 +64,20 @@ module NetSuite
               custom_field_value = custom_field.value.to_s
             end
 
-            {
+            base = {
               "platformCore:value" => custom_field_value,
-              '@internalId' => custom_field.internal_id,
               '@xsi:type' => custom_field.type
             }
+
+            if custom_field.internal_id
+              base['@internalId'] = custom_field.internal_id
+            end
+
+            if custom_field.script_id
+              base['@scriptId'] = custom_field.script_id
+            end
+
+            base
           end
         }
       end

--- a/spec/netsuite/records/custom_field_list_spec.rb
+++ b/spec/netsuite/records/custom_field_list_spec.rb
@@ -47,6 +47,11 @@ describe NetSuite::Records::CustomFieldList do
         :type        => 'SelectCustomFieldRef',
         :value       => NetSuite::Records::CustomRecordRef.new(:internal_id => 13, :name => "The Name")
       )
+      list.custom_fields << NetSuite::Records::CustomField.new(
+        :script_id   => 'custbody_accountclassification',
+        :type        => 'SelectCustomFieldRef',
+        :value       => NetSuite::Records::CustomRecordRef.new(:internal_id => 11, :name => "The Game")
+      )
     end
 
     it 'can represent itself as a SOAP record' do
@@ -61,6 +66,11 @@ describe NetSuite::Records::CustomFieldList do
             '@internalId' => 'custbody_salesclassification',
             '@xsi:type' => 'SelectCustomFieldRef',
             "platformCore:value"=>{"platformCore:name"=>"The Name", :@internalId=>13}
+          },
+          {
+            '@scriptId' => 'custbody_accountclassification',
+            '@xsi:type' => 'SelectCustomFieldRef',
+            "platformCore:value"=>{"platformCore:name"=>"The Game", :@internalId=>11}
           }
         ]
       }


### PR DESCRIPTION
When creating a new record with custom fields, the internal id is
unknown.
