### PR TITLE
Avoid unnecessary mutation

### DIFF
--- a/lib/netsuite/actions/search.rb
+++ b/lib/netsuite/actions/search.rb
@@ -22,7 +22,7 @@ module NetSuite
         # https://system.netsuite.com/help/helpcenter/en_US/Output/Help/SuiteCloudCustomizationScriptingWebServices/SuiteTalkWebServices/SettingSearchPreferences.html
         # https://webservices.netsuite.com/xsd/platform/v2012_2_0/messages.xsd
 
-        preferences = NetSuite::Configuration.auth_header(credentials).update(
+        preferences = NetSuite::Configuration.auth_header(credentials).merge(
           (@options.delete(:preferences) || {}).inject({'platformMsgs:SearchPreferences' => {}}) do |h, (k, v)|
             h['platformMsgs:SearchPreferences'][k.to_s.lower_camelcase] = v
             h


### PR DESCRIPTION
I ran into an unexpected behavior when the `getSelectValue` respond body was including a search body:

```
[1] pry(#<NetSuite::Actions::GetSelectValue>)> @response.body
=> {:search_response=>
  {:search_result=>
    {:status=>{:@is_success=>"true"},
     :total_records=>"1",
     :page_size=>"1000",
     :total_pages=>"1",
     :page_index=>"1",
     :search_id=>"WEBSERVICES_3868171_1023201410570198521023020047_dc09b6504f2",
     :record_list=>
#...
```

I realized that `Search` is mutating the auth headers when it uses `update`. 
