### PR TITLE
Credential fix for search

### DIFF
--- a/lib/netsuite/actions/search.rb
+++ b/lib/netsuite/actions/search.rb
@@ -30,7 +30,7 @@ module NetSuite
         )
 
         NetSuite::Configuration
-          .connection(soap_header: preferences)
+          .connection({ soap_header: preferences }, credentials)
           .call (@options.has_key?(:search_id)? :search_more_with_id : :search), :message => request_body
       end
 

--- a/spec/netsuite/actions/search_spec.rb
+++ b/spec/netsuite/actions/search_spec.rb
@@ -11,7 +11,7 @@ describe NetSuite::Actions::Search do
       email: 'fake@domain.com',
       password: 'fake'
     }
-NetSuite::Records::Customer.search({}, credentials)
+    NetSuite::Records::Customer.search({}, credentials)
 
     expect(NetSuite::Configuration).to have_received(:connection).with({:soap_header=>{
       "platformMsgs:passport"=>{

--- a/spec/netsuite/actions/search_spec.rb
+++ b/spec/netsuite/actions/search_spec.rb
@@ -7,10 +7,11 @@ describe NetSuite::Actions::Search do
   it "handles custom auth credentials" do
     allow(NetSuite::Configuration).to receive(:connection).and_return(double().as_null_object)
 
-    NetSuite::Records::Customer.search({}, {
+    credentials = {
       email: 'fake@domain.com',
       password: 'fake'
-    })
+    }
+NetSuite::Records::Customer.search({}, credentials)
 
     expect(NetSuite::Configuration).to have_received(:connection).with({:soap_header=>{
       "platformMsgs:passport"=>{
@@ -18,7 +19,7 @@ describe NetSuite::Actions::Search do
         "platformCore:password"=>"fake",
         "platformCore:account"=>"1234",
         "platformCore:role"=>{:@internalId=>"3"}
-      }, "platformMsgs:SearchPreferences"=>{}}}
+      }, "platformMsgs:SearchPreferences"=>{}}}, credentials
     )
   end
 


### PR DESCRIPTION
If credentials are not specified in a `NetSuite.config` block, then `#search` actions fail.

Since `#search` passes its credentials into `NetSuite::Configuration.connection` as a SOAP header, it doesn't bother to pass the credentials to `.connection`.  Ultimately, `auth_header({})` is called which tries to find the credentials in the default configuration.  Since they aren't set, `#email` or `#password` (whichever one is called first) raises an error.

My solution is to pass the credentials from `#search` into `#connection` anyway.  This seemed to be the most straightforward to me.  `#auth_header` was already being called unnecessarily, so this solution isn't any less efficient.