### PR TITLE
Fixed problem in CustomerPaymentApplyList to_record

### DIFF
--- a/lib/netsuite/records/customer_payment_apply_list.rb
+++ b/lib/netsuite/records/customer_payment_apply_list.rb
@@ -1,14 +1,21 @@
 module NetSuite
   module Records
     class CustomerPaymentApplyList
+      include Support::Fields
       include Namespaces::TranCust
 
+      fields :apply
+
       def initialize(attributes = {})
-        case attributes[:apply]
-        when Hash
-          applies << CustomerPaymentApply.new(attributes[:apply])
-        when Array
-          attributes[:apply].each { |apply| applies << CustomerPaymentApply.new(apply) }
+        initialize_from_attributes_hash(attributes)
+      end
+
+      def apply=(applies)
+        case applies
+          when Hash
+            self.applies << CustomerPaymentApply.new(applies)
+          when Array
+            applies.each { |apply| self.applies << CustomerPaymentApply.new(apply) }
         end
       end
 
@@ -17,9 +24,7 @@ module NetSuite
       end
 
       def to_record
-        applies.map do |apply|
-          { "#{record_namespace}:apply" => apply.to_record }
-        end
+        { "#{record_namespace}:apply" => applies.map(&:to_record) }
       end
 
     end

--- a/spec/netsuite/records/customer_payment_apply_list_spec.rb
+++ b/spec/netsuite/records/customer_payment_apply_list_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe NetSuite::Records::CustomerPaymentApplyList do
+  let(:list) { NetSuite::Records::CustomerPaymentApplyList.new }
+  let(:apply) { NetSuite::Records::CustomerPaymentApply.new }
+
+  it 'can have applies be added to it' do
+    list.applies << apply
+    apply_list = list.applies
+    expect(apply_list).to be_kind_of(Array)
+    expect(apply_list.length).to eql(1)
+    apply_list.each { |i| expect(i).to be_kind_of(NetSuite::Records::CustomerPaymentApply) }
+  end
+
+  describe '#to_record' do
+    it 'can represent itself as a SOAP record' do
+      record = {
+          'tranCust:apply' => [{},{}]
+      }
+      list.applies.concat([apply,apply])
+      expect(list.to_record).to eql(record)
+    end
+  end
+
+end


### PR DESCRIPTION
The applyList for a CustomerPayment is not structured correctly in requests to NetSuite.  This fix changes the format from: 
```
<platformMsgs:record xsi:type="tranCust:CustomerPayment" ...  >     
   <tranCust:applyList>
       <tranCust:apply>..</tranCust:apply>
   </tranCust:applyList>
   <tranCust:applyList>
       <tranCust:apply>..</tranCust:apply>
   </tranCust:applyList>
   ...
</platformMsgs:record>

to:

<platformMsgs:record xsi:type="tranCust:CustomerPayment" ...  >     
   <tranCust:applyList>
       <tranCust:apply>..</tranCust:apply> 
       <tranCust:apply>..</tranCust:apply>
      ...
   </tranCust:applyList>
</platformMsgs:record>
```

@iloveitaly
