### PR TITLE
Make test suite run without failing tests

### DIFF
--- a/lib/netsuite/records/payment_method.rb
+++ b/lib/netsuite/records/payment_method.rb
@@ -5,8 +5,7 @@ module NetSuite
       include Support::RecordRefs
       include Support::Actions
 
-      actions :add, :delete, :get, :get_list, :search, :search_more_with_id,
-        :update, :upsert, :upsert_list
+      actions :add, :delete, :get, :get_list, :search, :update, :upsert, :upsert_list
 
       fields :credit_card, :express_checkout_arrangement, :is_debit_card, :is_inactive, :is_online, :name,
         :pay_pal_email_address, :undep_funds, :use_express_checkout

--- a/lib/netsuite/support/actions.rb
+++ b/lib/netsuite/support/actions.rb
@@ -28,8 +28,6 @@ module NetSuite
             self.send(:include, NetSuite::Actions::GetSelectValue::Support)
           when :search
             self.send(:include, NetSuite::Actions::Search::Support)
-          when :search_more_with_id
-            self.send(:include, NetSuite::Actions::SearchMoreWithId::Support)
           when :add
             self.send(:include, NetSuite::Actions::Add::Support)
           when :upsert

--- a/spec/netsuite/actions/login_spec.rb
+++ b/spec/netsuite/actions/login_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
 describe NetSuite::Actions::Login do
-  it 'properly executes a login call' do
-    savon.mock!
+  before { savon.mock! }
+  after { savon.unmock! }
 
+  it 'properly executes a login call' do
     message = {"platformMsgs:passport"=>{"platformCore:email"=>"email", "platformCore:password"=>"password", "platformCore:account"=>"1234", "platformCore:role"=>234}}
 
     savon.expects(:login).with(:message => message).returns(File.read('spec/support/fixtures/login.xml'))


### PR DESCRIPTION
This fixes some of the inconsistently failing tests and finishes removing `search_more_with_id` as started in https://github.com/NetSweet/netsuite/commit/faabd7a657a076d9552fe1ee4834ce8aa69a63f7