### PR TITLE
Update savon and pray it doesn't break everything

### DIFF
--- a/netsuite.gemspec
+++ b/netsuite.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Netsuite::VERSION
 
-  gem.add_dependency 'savon', '~> 2.3.0'
+  gem.add_dependency 'savon', '~> 2.10.0'
 
   gem.add_development_dependency 'rspec', '~> 3.1.0'
 end


### PR DESCRIPTION
Update savon from ```~> 2.3.0``` to ```~> 2.10.0``` to resolve the following dependency conflicts with Rails 4.2
```
Bundler could not find compatible versions for gem "mime-types":
  In Gemfile:
    netsuite (>= 0) ruby depends on
      savon (~> 2.3.0) ruby depends on
        wasabi (~> 3.2.0) ruby depends on
          mime-types (< 2.0.0) ruby

    rails (= 4.2.0) ruby depends on
      actionmailer (= 4.2.0) ruby depends on
        mail (>= 2.5.4, ~> 2.5) ruby depends on
          mime-types (2.4.3)

Bundler could not find compatible versions for gem "nokogiri":
  In Gemfile:
    netsuite (>= 0) ruby depends on
      savon (~> 2.3.0) ruby depends on
        nokogiri (< 1.6, >= 1.4.0) ruby

    rails (= 4.2.0) ruby depends on
      actionmailer (= 4.2.0) ruby depends on
        rails-dom-testing (>= 1.0.5, ~> 1.0) ruby depends on
          nokogiri (1.6.6.2)
```