### PR TITLE
Specify the appropriate klass for subsidiary_list fields

### DIFF
--- a/lib/netsuite/records/classification.rb
+++ b/lib/netsuite/records/classification.rb
@@ -6,7 +6,9 @@ module NetSuite
 
       actions :get, :get_list, :delete, :upsert
 
-      fields :name, :include_children, :is_inactive, :class_translation_list, :subsidiary_list, :custom_field_list
+      fields :name, :include_children, :is_inactive, :class_translation_list, :custom_field_list
+
+      field :subsidiary_list, RecordRefList
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/discount_item.rb
+++ b/lib/netsuite/records/discount_item.rb
@@ -14,9 +14,10 @@ module NetSuite
 
       record_refs :account, :custom_form, :deferred_revenue_account, :department, :expense_account,
         :income_account, :issue_product, :klass, :location, :parent, :rev_rec_schedule, :sales_tax_code,
-        :subsidiary_list, :tax_schedule
+        :tax_schedule
 
       field :custom_field_list, CustomFieldList
+      field :subsidiary_list, RecordRefList
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/non_inventory_sale_item.rb
+++ b/lib/netsuite/records/non_inventory_sale_item.rb
@@ -28,12 +28,13 @@ module NetSuite
       record_refs :billing_schedule, :cost_category, :custom_form, :deferred_revenue_account, :department, :income_account,
         :issue_product, :item_options_list, :klass, :location, :parent, :pricing_group, :purchase_tax_code,
         :quantity_pricing_schedule, :rev_rec_schedule, :sale_unit, :sales_tax_code, :ship_package, :store_display_image,
-        :store_display_thumbnail, :store_item_template, :subsidiary_list, :tax_schedule, :units_type
+        :store_display_thumbnail, :store_item_template, :tax_schedule, :units_type
 
-      field :pricing_matrix, PricingMatrix
       field :custom_field_list, CustomFieldList
       field :pricing_matrix, PricingMatrix
-      
+      field :subsidiary_list, RecordRefList
+
+
       attr_reader   :internal_id
       attr_accessor :external_id
 

--- a/lib/netsuite/records/service_sale_item.rb
+++ b/lib/netsuite/records/service_sale_item.rb
@@ -26,10 +26,11 @@ module NetSuite
       record_refs :billing_schedule, :cost_category, :custom_form, :deferred_revenue_account, :department, :income_account,
         :issue_product, :item_options_list, :klass, :location, :parent, :pricing_group, :purchase_tax_code,
         :quantity_pricing_schedule, :rev_rec_schedule, :sale_unit, :sales_tax_code, :store_display_image,
-        :store_display_thumbnail, :store_item_template, :subsidiary_list, :tax_schedule, :units_type
+        :store_display_thumbnail, :store_item_template, :tax_schedule, :units_type
 
       field :pricing_matrix, PricingMatrix
       field :custom_field_list, CustomFieldList
+      field :subsidiary_list, RecordRefList
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/spec/netsuite/records/classification_spec.rb
+++ b/spec/netsuite/records/classification_spec.rb
@@ -5,10 +5,12 @@ describe NetSuite::Records::Classification do
 
   it 'has all the right fields' do
     [
-      :name, :include_children, :is_inactive, :class_translation_list, :subsidiary_list, :custom_field_list
+      :name, :include_children, :is_inactive, :class_translation_list, :custom_field_list
     ].each do |field|
       expect(classification).to have_field(field)
     end
+
+    expect(classification.subsidiary_list.class).to eq(NetSuite::Records::RecordRefList)
   end
 
   describe '.get' do

--- a/spec/netsuite/records/discount_item_spec.rb
+++ b/spec/netsuite/records/discount_item_spec.rb
@@ -13,13 +13,14 @@ describe NetSuite::Records::DiscountItem do
 
     # TODO there is a probably a more robust way to test this
     expect(item.custom_field_list.class).to eq(NetSuite::Records::CustomFieldList)
+    expect(item.subsidiary_list.class).to eq(NetSuite::Records::RecordRefList)
   end
 
   it 'has the right record_refs' do
     [
       :account, :custom_form, :deferred_revenue_account, :department, :expense_account,
       :income_account, :issue_product, :klass, :location, :parent, :rev_rec_schedule, :sales_tax_code,
-      :subsidiary_list, :tax_schedule
+      :tax_schedule
     ].each do |record_ref|
       expect(item).to have_record_ref(record_ref)
     end

--- a/spec/netsuite/records/non_inventory_sale_item_spec.rb
+++ b/spec/netsuite/records/non_inventory_sale_item_spec.rb
@@ -26,6 +26,7 @@ describe NetSuite::Records::NonInventorySaleItem do
     # TODO there is a probably a more robust way to test this
     expect(item.custom_field_list.class).to eq(NetSuite::Records::CustomFieldList)
     expect(item.pricing_matrix.class).to eq(NetSuite::Records::PricingMatrix)
+    expect(item.subsidiary_list.class).to eq(NetSuite::Records::RecordRefList)
   end
 
   it 'has the right record_refs' do
@@ -33,7 +34,7 @@ describe NetSuite::Records::NonInventorySaleItem do
       :billing_schedule, :cost_category, :custom_form, :deferred_revenue_account, :department, :income_account, :issue_product,
       :item_options_list, :klass, :location, :parent, :pricing_group, :purchase_tax_code, :quantity_pricing_schedule,
       :rev_rec_schedule, :sale_unit, :sales_tax_code, :ship_package, :store_display_image, :store_display_thumbnail,
-      :store_item_template, :subsidiary_list, :tax_schedule, :units_type
+      :store_item_template, :tax_schedule, :units_type
     ].each do |record_ref|
       expect(item).to have_record_ref(record_ref)
     end

--- a/spec/netsuite/records/service_sale_item_spec.rb
+++ b/spec/netsuite/records/service_sale_item_spec.rb
@@ -22,6 +22,7 @@ describe NetSuite::Records::ServiceSaleItem do
     # TODO there is a probably a more robust way to test this
     expect(item.custom_field_list.class).to eq(NetSuite::Records::CustomFieldList)
     expect(item.pricing_matrix.class).to eq(NetSuite::Records::PricingMatrix)
+    expect(item.subsidiary_list.class).to eq(NetSuite::Records::RecordRefList)
   end
 
   it 'has the right record_refs' do
@@ -29,7 +30,7 @@ describe NetSuite::Records::ServiceSaleItem do
       :billing_schedule, :cost_category, :custom_form, :deferred_revenue_account, :department, :income_account,
       :issue_product, :item_options_list, :klass, :location, :parent, :pricing_group, :purchase_tax_code,
       :quantity_pricing_schedule, :rev_rec_schedule, :sale_unit, :sales_tax_code, :store_display_image,
-      :store_display_thumbnail, :store_item_template, :subsidiary_list, :tax_schedule, :units_type
+      :store_display_thumbnail, :store_item_template, :tax_schedule, :units_type
     ].each do |record_ref|
       expect(item).to have_record_ref(record_ref)
     end


### PR DESCRIPTION
Solves https://github.com/NetSweet/netsuite/issues/190 by following the pattern from:
https://github.com/NetSweet/netsuite/blob/master/lib/netsuite/records/inventory_item.rb#L61
https://github.com/NetSweet/netsuite/blob/master/lib/netsuite/records/assembly_item.rb#L47

It fixed my issue with `ServiceSaleItem` so I'm assuming it's the right fix for the other classes as well, but I didn't actually test out creating them yet.