### PR TITLE
Invoice's subsidiary should be a record_ref

### DIFF
--- a/lib/netsuite/records/invoice.rb
+++ b/lib/netsuite/records/invoice.rb
@@ -24,7 +24,7 @@ module NetSuite
         :rev_rec_on_rev_commitment, :rev_rec_schedule, :rev_rec_start_date, :revenue_status, :sales_effective_date,
         :sales_group, :sales_team_list, :ship_address, :ship_date, :ship_group_list,
         :shipping_cost, :shipping_tax_1_rate, :shipping_tax_2_rate, :shipping_tax_code, :source, :start_date,
-        :status, :subsidiary, :sync_partner_teams, :sync_sales_teams, :tax_2_total,
+        :status, :sync_partner_teams, :sync_sales_teams, :tax_2_total,
         :tax_total, :time_disc_amount, :time_disc_print, :time_disc_rate, :time_disc_tax_1_amt, :time_disc_taxable,
         :time_discount, :time_list, :time_tax_code, :time_tax_rate_1, :time_tax_rate_2, :to_be_emailed, :to_be_faxed,
         :to_be_printed, :total_cost_estimate, :tracking_numbers, :tran_date, :tran_id, :tran_is_vsoe_bundle,
@@ -40,7 +40,7 @@ module NetSuite
 
       record_refs :account, :bill_address_list, :custom_form, :department, :entity, :klass, :partner,
                   :posting_period, :ship_address_list, :terms, :location, :sales_rep, :tax_item, :created_from,
-                  :ship_method, :lead_source, :promo_code
+                  :ship_method, :lead_source, :promo_code, :subsidiary
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/spec/netsuite/records/invoice_spec.rb
+++ b/spec/netsuite/records/invoice_spec.rb
@@ -22,7 +22,7 @@ describe NetSuite::Records::Invoice do
       :rev_rec_on_rev_commitment, :rev_rec_schedule, :rev_rec_start_date, :revenue_status, :sales_effective_date,
       :sales_group, :sales_team_list, :ship_address, :ship_date, :ship_group_list,
       :shipping_cost, :shipping_tax_1_rate, :shipping_tax_2_rate, :shipping_tax_code, :source, :start_date,
-      :status, :subsidiary, :sync_partner_teams, :sync_sales_teams, :tax_2_total,
+      :status, :sync_partner_teams, :sync_sales_teams, :tax_2_total,
       :tax_total, :time_disc_amount, :time_disc_print, :time_disc_rate, :time_disc_tax_1_amt, :time_disc_taxable,
       :time_discount, :time_list, :time_tax_code, :time_tax_rate_1, :time_tax_rate_2, :to_be_emailed, :to_be_faxed,
       :to_be_printed, :total_cost_estimate, :tracking_numbers, :tran_date, :tran_id, :tran_is_vsoe_bundle,
@@ -44,7 +44,7 @@ describe NetSuite::Records::Invoice do
   it 'has the right record_refs' do
     [
       :account, :bill_address_list, :custom_form, :department, :entity, :klass, :posting_period, :ship_address_list, :terms,
-      :created_from, :location, :sales_rep, :ship_method, :tax_item, :partner, :lead_source, :promo_code
+      :created_from, :location, :sales_rep, :ship_method, :tax_item, :partner, :lead_source, :promo_code, :subsidiary
     ].each do |record_ref|
       expect(invoice).to have_record_ref(record_ref)
     end


### PR DESCRIPTION
Everywhere else subsidiary is a `record_ref` so just seems like this one got missed.