### PR TITLE
Add handling for WSDL 2013.2 CustomField internalId-scriptId transition

### DIFF
--- a/spec/netsuite/records/custom_field_list_spec.rb
+++ b/spec/netsuite/records/custom_field_list_spec.rb
@@ -7,31 +7,77 @@ describe NetSuite::Records::CustomFieldList do
     expect(list.custom_fields).to be_kind_of(Array)
   end
 
-  context 'writing convience methods' do
-    it "should create a custom field entry when none exists" do
-      list.custrecord_somefield = 'a value'
-      expect(list.custom_fields.size).to eq(1)
-      expect(list.custom_fields.first.value).to eq('a value')
-      expect(list.custom_fields.first.type).to eq('platformCore:StringCustomFieldRef')
-    end
+  context 'custom field internalId-to-scriptId transition at WSDL 2013_2:' do
+    before(:context) { @reset = NetSuite::Configuration.api_version }
+    after(:context)  { NetSuite::Configuration.api_version = @reset }
 
-    it "should handle date custom field creation" do
-      list.custrecord_somefield = Date.parse("12/12/2012")
-      expect(list.custom_fields.first.value).to eq('2012-12-12T00:00:00+00:00')
-    end
+    transition_version = '2013_2'
 
-    it "should handle datetime custom field creation" do
-      list.custrecord_somefield = DateTime.parse("12/12/2012 10:05am")
-      expect(list.custom_fields.first.value).to eq('2012-12-12T10:05:00+00:00')
-    end
+    ['2012_2', '2013_2', '2014_2'].each do |version|
 
-    it "should convert a list of numbers into a list of custom field refs" do
-      list.custrecord_somefield = [1,2]
-      expect(list.custom_fields.first.type).to eq('platformCore:MultiSelectCustomFieldRef')
-      expect(list.custom_fields.first.value.map(&:to_record)).to eql([
-        NetSuite::Records::CustomRecordRef.new(:internal_id => 1),
-        NetSuite::Records::CustomRecordRef.new(:internal_id => 2)
-      ].map(&:to_record))
+      comparison = ['==', '>', '<'][version <=> transition_version]
+
+      context "when WSDL version #{comparison} #{transition_version}," do
+        before { NetSuite::Configuration.api_version = version }
+
+        context 'convenience methods' do
+          reference_id_type = version < transition_version ? :internal_id : :script_id
+
+          it "should create a custom field entry when none exists" do
+            list.some_custom_field = 'a value'
+
+            expect(list.custom_fields.size).to eq(1)
+            expect(list.custom_fields.first.value).to eq('a value')
+            expect(list.custom_fields.first.type).to eq('platformCore:StringCustomFieldRef')
+          end
+
+          it "should set #{reference_id_type} to method name when creating a custom field" do
+            list.some_custom_field = 'a value'
+
+            expect(list.some_custom_field.send(reference_id_type)).to eq('some_custom_field')
+          end
+
+          it "should update a custom field's value when one exists" do
+            list.existing_custom_field = 'old value'
+            list.existing_custom_field = 'new value'
+
+            expect(list.existing_custom_field.value).to eq('new value')
+          end
+
+          it "should handle date custom field creation" do
+            list.some_custom_field = Date.parse("12/12/2012")
+
+            expect(list.custom_fields.first.value).to eq('2012-12-12T00:00:00+00:00')
+          end
+
+          it "should handle datetime custom field creation" do
+            list.some_custom_field = DateTime.parse("12/12/2012 10:05am")
+
+            expect(list.custom_fields.first.value).to eq('2012-12-12T10:05:00+00:00')
+          end
+
+          it "should convert a list of numbers into a list of custom field refs" do
+            list.some_custom_field = [1,2]
+
+            expect(list.custom_fields.first.type).to eq('platformCore:MultiSelectCustomFieldRef')
+            expect(list.custom_fields.first.value.map(&:to_record)).to eql([
+              NetSuite::Records::CustomRecordRef.new(:internal_id => 1),
+              NetSuite::Records::CustomRecordRef.new(:internal_id => 2)
+            ].map(&:to_record))
+          end
+
+          it "should return custom field record when entry exists" do
+            list.existing_custom_field = 'a value'
+
+            expect(list.existing_custom_field).to be_a(NetSuite::Records::CustomField)
+            expect(list.existing_custom_field.value).to eq('a value')
+          end
+
+          it "should raise an error if custom field entry does not exist" do
+            expect{ list.nonexisting_custom_field }.to raise_error
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fix for issues #196 & #207 

Apparently, at NS SuiteTalk WSDL version 2013.2, CustomField ```internalId``` values were migrated to ```scriptId```s and the ```internalId``` values replaced with generated numeric ids. This was breaking CustomFieldList adds and updates when using WSDL 2013.2 and beyond.  The changes contained in this PR should address this problem.