### PR TITLE
Add search namespace override to JournalEntry

### DIFF
--- a/lib/netsuite/records/journal_entry.rb
+++ b/lib/netsuite/records/journal_entry.rb
@@ -39,6 +39,10 @@ module NetSuite
         "Transaction"
       end
 
+      def self.search_class_namespace
+        "tranSales"
+      end
+
     end
   end
 end


### PR DESCRIPTION
The namespace for JournalEntry is tranGeneral, but it's search falls under the Transaction schema with the namespace tranSales. Add a search_class_namespace override to make this work properly.