### PR TITLE
Token-based authentication

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -203,6 +203,11 @@ module NetSuite
     autoload :WorkOrderItemList,                'netsuite/records/work_order_item_list'
   end
 
+  module Passports
+    autoload :User,  'netsuite/passports/user'
+    autoload :Token, 'netsuite/passports/token'
+  end
+
   def self.configure(&block)
     NetSuite::Configuration.instance_eval(&block)
   end

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -99,14 +99,30 @@ module NetSuite
     end
 
     def auth_header(credentials={})
-      {
-        'platformMsgs:passport' => {
-          'platformCore:email'    => credentials[:email] || email,
-          'platformCore:password' => credentials[:password] || password,
-          'platformCore:account'  => credentials[:account] || account.to_s,
-          'platformCore:role'     => { :@internalId => credentials[:role] || role }
-        }
-      }
+      if credentials[:consumer_key].present? || consumer_key.present?
+        token_auth(credentials)
+      else
+        user_auth(credentials)
+      end
+    end
+
+    def user_auth(credentials)
+      NetSuite::Passports::User.new(
+        credentials[:account] || account,
+        credentials[:email] || email,
+        credentials[:password] || password,
+        credentials[:role] || role
+      ).passport
+    end
+
+    def token_auth(credentials)
+      NetSuite::Passports::Token.new(
+        credentials[:account] || account,
+        credentials[:consumer_key] || consumer_key,
+        credentials[:consumer_secret] || consumer_secret,
+        credentials[:token_id] || token_id,
+        credentials[:token_secret] || token_secret
+      ).passport
     end
 
     def namespaces
@@ -178,6 +194,54 @@ module NetSuite
         self.account = account
       else
         attributes[:account]
+      end
+    end
+
+    def consumer_key=(consumer_key)
+      attributes[:consumer_key] = consumer_key
+    end
+
+    def consumer_key(consumer_key = nil)
+      if consumer_key
+        self.consumer_key = consumer_key
+      else
+        attributes[:consumer_key]
+      end
+    end
+
+    def consumer_secret=(consumer_secret)
+      attributes[:consumer_secret] = consumer_secret
+    end
+
+    def consumer_secret(consumer_secret = nil)
+      if consumer_secret
+        self.consumer_secret = consumer_secret
+      else
+        attributes[:consumer_secret]
+      end
+    end
+
+    def token_id=(token_id)
+      attributes[:token_id] = token_id
+    end
+
+    def token_id(token_id = nil)
+      if token_id
+        self.token_id = token_id
+      else
+        attributes[:token_id]
+      end
+    end
+
+    def token_secret=(token_secret)
+      attributes[:token_secret] = token_secret
+    end
+
+    def token_secret(token_secret = nil)
+      if token_secret
+        self.token_secret = token_secret
+      else
+        attributes[:token_secret]
       end
     end
 

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -99,7 +99,7 @@ module NetSuite
     end
 
     def auth_header(credentials={})
-      if credentials[:consumer_key].present? || consumer_key.present?
+      if !credentials[:consumer_key].blank? || !consumer_key.blank?
         token_auth(credentials)
       else
         user_auth(credentials)

--- a/lib/netsuite/passports/token.rb
+++ b/lib/netsuite/passports/token.rb
@@ -1,0 +1,55 @@
+module NetSuite
+  module Passports
+    class Token
+      attr_reader :account, :consumer_key, :consumer_secret, :token_id, :token_secret
+
+      def initialize(account, consumer_key, consumer_secret, token_id, token_secret)
+        @account = account
+        @consumer_key = consumer_key
+        @consumer_secret = consumer_secret
+        @token_id = token_id
+        @token_secret = token_secret
+      end
+
+      def passport
+        {
+          'platformMsgs:tokenPassport' => {
+            'platformCore:account' => account,
+            'platformCore:consumerKey' => consumer_key,
+            'platformCore:token' => token_id,
+            'platformCore:nonce' => nonce,
+            'platformCore:timestamp' => timestamp,
+            'platformCore:signature' => signature,
+            :attributes! => { 'platformCore:signature' => { 'algorithm' => 'HMAC-SHA256' } }
+          }
+        }
+      end
+
+      private
+
+      def signature
+        Base64.encode64(OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'), signature_key, signature_data))
+      end
+
+      def signature_key
+        "#{consumer_secret}&#{token_secret}"
+      end
+
+      def signature_data
+        "#{account}&#{consumer_key}&#{token_id}&#{nonce}&#{timestamp}"
+      end
+
+      def nonce
+        @nonce ||= Array.new(20) { alphanumerics.sample }.join
+      end
+
+      def alphanumerics
+        [*'0'..'9',*'A'..'Z',*'a'..'z']
+      end
+
+      def timestamp
+        @timestamp ||= Time.now.to_i
+      end
+    end
+  end
+end

--- a/lib/netsuite/passports/token.rb
+++ b/lib/netsuite/passports/token.rb
@@ -4,7 +4,7 @@ module NetSuite
       attr_reader :account, :consumer_key, :consumer_secret, :token_id, :token_secret
 
       def initialize(account, consumer_key, consumer_secret, token_id, token_secret)
-        @account = account
+        @account = account.to_s
         @consumer_key = consumer_key
         @consumer_secret = consumer_secret
         @token_id = token_id

--- a/lib/netsuite/passports/user.rb
+++ b/lib/netsuite/passports/user.rb
@@ -1,0 +1,25 @@
+module NetSuite
+  module Passports
+    class User
+      attr_reader :account, :email, :password, :role
+
+      def initialize(account, email, password, role)
+        @account = account
+        @email = email
+        @password = password
+        @role = role
+      end
+
+      def passport
+        {
+          'platformMsgs:passport' => {
+            'platformCore:account'  => account,
+            'platformCore:email'    => email,
+            'platformCore:password' => password,
+            'platformCore:role'     => { :@internalId => role }
+          }
+        }
+      end
+    end
+  end
+end

--- a/lib/netsuite/passports/user.rb
+++ b/lib/netsuite/passports/user.rb
@@ -4,7 +4,7 @@ module NetSuite
       attr_reader :account, :email, :password, :role
 
       def initialize(account, email, password, role)
-        @account = account
+        @account = account.to_s
         @email = email
         @password = password
         @role = role


### PR DESCRIPTION
What do you think about this for allowing token-based auth?

Instead of setting email, password, and role in the config, you add: consumer_key, consumer_secret, token_id, and token_secret.

(Note, you can't include ApplicationInfo when doing token-based auth--you'll get an error. I think it would be better if application_id was set in the config, and it included that in the header only when doing token-based auth.)

I've tested it with both user auth and token auth and it's working for me.

I'm not super happy with the way it chooses auth methods (configuration.rb:102)...any thoughts on how to make that better? Maybe it's better to have another config option for auth_type?

Also, I'm not sure the best way to test auth header hash, since the nonce, timestamp and signature can't be hard-coded (configuration_spec.rb:86).