### PR TITLE
Define search namespaces to allow searching on VendorBills

### DIFF
--- a/lib/netsuite/records/vendor_bill.rb
+++ b/lib/netsuite/records/vendor_bill.rb
@@ -40,6 +40,14 @@ module NetSuite
         rec
       end
 
+      def self.search_class_name
+        "Transaction"
+      end
+
+      def self.search_class_namespace
+        'tranSales'
+      end
+
     end
   end
 end


### PR DESCRIPTION
NetSuite doesn't define a VendorBillSearch. It [expects](https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2015_2/schema/record/vendorbill.html) you to use a TransactionSearch instead. But [TransactionSearches](https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2015_2/schema/search/transactionsearch.html?mode=package) use the `sales.transactions` namespace, whereas VendorBills use the `purchases.transactions` namespace.

This is an issue because the `purcahses.transactions` namespace is likely required for some actions, just not the search.

This commit overrides the namespaces used for the search action on VendorBills to make searching possible. Without it, you end up with the following error message:

```ruby
NetSuite::Records::VendorBill.search
Savon::SOAPFault: (soapenv:Server.userException) org.xml.sax.SAXException: Invalid type: {urn:purchases_2015_1.transactions.webservices.netsuite.com}VendorBillSearch
```