### PR TITLE
Reimplementing KitItem class

### DIFF
--- a/lib/netsuite/records/kit_item.rb
+++ b/lib/netsuite/records/kit_item.rb
@@ -9,46 +9,50 @@ module NetSuite
 
       actions :get, :get_list, :add, :delete, :search, :update, :upsert
 
-      fields :auto_lead_time, :auto_preferred_stock_level, :auto_reorder_point, :available_to_partners, :average_cost,
-        :copy_description, :cost, :cost_estimate, :cost_estimate_type, :cost_estimate_units, :cost_units, :costing_method,
-        :costing_method_display, :country_of_manufacture, :created_date, :currency, :date_converted_to_inv,
-        :default_return_cost, :demand_modifier, :display_name, :dont_show_price, :enforce_min_qty_internally,
-        :exclude_from_sitemap, :featured_description, :fixed_lot_size, :handling_cost, :handling_cost_units, :include_children,
-        :is_donation_item, :is_drop_ship_item, :is_gco_compliant, :is_inactive, :is_online, :is_special_order_item, :is_taxable,
-        :item_id, :last_modified_date, :last_purchase_price, :lead_time, :manufacturer, :manufacturer_addr1, :manufacturer_city,
-        :manufacturer_state, :manufacturer_tariff, :manufacturer_tax_id, :manufacturer_zip, :match_bill_to_receipt,
-        :matrix_type, :max_donation_amount, :meta_tag_html, :minimum_quantity, :minimum_quantity_units, :mpn,
-        :mult_manufacture_addr, :nex_tag_category, :no_price_message, :offer_support, :on_hand_value_mli, :on_special,
-        :original_item_subtype, :original_item_type, :out_of_stock_behavior, :out_of_stock_message,
-        :overall_quantity_pricing_type, :page_title, :preference_criterion, :preferred_stock_level, :preferred_stock_level_days,
-        :preferred_stock_level_units, :prices_include_tax, :producer, :purchase_description, :quantity_available,
-        :quantity_available_units, :quantity_back_ordered, :quantity_committed, :quantity_committed_units, :quantity_on_hand,
-        :quantity_on_hand_units, :quantity_on_order, :quantity_on_order_units, :quantity_reorder_units, :rate,
-        :related_items_description, :reorder_multiple, :reorder_point, :reorder_point_units, :safety_stock_level,
-        :safety_stock_level_days, :safety_stock_level_units, :sales_description, :schedule_b_code, :schedule_b_number,
-        :schedule_b_quantity, :search_keywords, :seasonal_demand, :ship_individually, :shipping_cost, :shipping_cost_units,
-        :shopping_dot_com_category, :shopzilla_category_id, :show_default_donation_amount, :sitemap_priority,
-        :specials_description, :stock_description, :store_description, :store_detailed_description, :store_display_name,
-        :total_value, :track_landed_cost, :transfer_price, :upc_code, :url_component, :use_bins, :use_marginal_rates,
-        :vendor_name, :vsoe_deferral, :vsoe_delivered, :vsoe_permit_discount, :vsoe_price, :weight, :weight_unit, :weight_units
+      fields :available_to_partners, :cost_estimate, :created_date, :defer_rev_rec, :description, :display_name,
+        :dont_show_price, :enforce_min_qty_internally, :exclude_from_sitemap, :featured_description, :handling_cost,
+        :hazmat_hazard_class, :hazmat_id, :hazmat_item_units, :hazmat_item_units_qty, :hazmat_shipping_name, :include_children,
+        :is_donation_item, :is_fulfillable, :is_gco_compliant, :is_hazmat_item, :is_inactive, :is_online, :is_taxable, :item_id,
+        :last_modified_date, :manufacturer, :manufactureraddr1, :manufacturer_city, :manufacturer_state, :manufacturer_tariff,
+        :manufacturer_tax_id, :manufacturer_zip, :max_donation_amount, :meta_tag_html, :minimum_quantity, :mpn,
+        :mult_manufacture_addr, :nex_tag_category, :no_price_message, :offer_support, :on_special, :out_of_stock_message,
+        :page_title, :prices_include_tax, :print_items, :producer, :rate, :related_items_description, :schedule_b_number,
+        :schedule_b_quantity, :search_keywords, :ship_individually, :shipping_cost, :shopping_dot_com_category,
+        :shopzilla_category_id, :show_default_donation_amount, :specials_description, :stock_description, :store_description,
+        :store_detailed_description, :store_display_name, :upc_code, :url_component, :use_marginal_rates, :vsoe_delivered,
+        :vsoe_price, :weight
 
-      record_refs :alternate_demand_source_item, :asset_account, :bill_exch_rate_variance_acct, :bill_price_variance_acct,
-        :bill_qty_variance_acct, :billing_schedule, :cogs_account, :cost_category, :custom_form, :deferred_revenue_account,
-        :demand_source, :department, :expense_account, :gain_loss_account, :income_account, :issue_product, :klass, :location,
-        :parent, :preferred_location, :pricing_group, :purchase_price_variance_acct, :purchase_tax_code, :purchase_unit,
-        :quantity_pricing_schedule, :rev_rec_schedule, :sale_unit, :sales_tax_code, :ship_package, :soft_descriptor,
-        :stock_unit, :store_display_image, :store_display_thumbnail, :store_item_template, :supply_lot_sizing_method,
-        :supply_replenishment_method, :supply_type, :tax_schedule, :units_type, :vendor
+      record_refs :billing_schedule, :custom_form, :default_item_ship_method, :deferred_revenue_account, :department,
+        :income_account, :issue_product, :item_revenue_category, :location, :parent, :pricing_group, :quantity_pricing_schedule,
+        :revenue_allocation_group, :revenue_recognition_rule, :rev_rec_schedule, :sales_tax_code, :schedule_b_code,
+        :ship_package, :soft_descriptor, :store_display_image, :store_display_thumbnail, :store_item_template, :tax_schedule,
+        :weight_unit
 
-      field :pricing_matrix, PricingMatrix
       field :custom_field_list, CustomFieldList
-      field :bin_number_list, BinNumberList
-      field :locations_list, LocationsList
-      field :matrix_option_list, MatrixOptionList
+      field :pricing_matrix, PricingMatrix
       field :subsidiary_list, RecordRefList
 
-      # for Assembly/Kit
-      field :member_list, MemberList
+      # TODO custom records need to be implemented
+      # field :accounting_book_detail_list, ItemAccountingBookDetailList
+      # field :cost_estimate_type, ItemCostEstimateType
+      # field :country_of_manufacture, Country
+      # field :create_revenue_plans_on, ItemCreateRevenuePlansOn
+      # field :hazmat_packing_group, HazmatPackingGroup
+      # field :item_carrier, ItemCarrier
+      # field :item_options_list, ItemOptionsList
+      # field :item_ship_method_list, RecordRefList
+      # field :member_list, ItemMemberList
+      # field :out_of_stock_behavior, ItemOutOfStockBehavior
+      # field :overall_quantity_pricing_type, ItemOverallQuantityPricingType
+      # field :preference_criterion, ItemPreferenceCriterion
+      # field :presentation_item_list, PresentationItemList
+      # field :product_feed_list, ProductFeedList
+      # field :site_category_list, SiteCategoryList
+      # field :sitemap_priority, SitemapPriority
+      # field :translations_list, TranslationList
+      # field :vsoe_deferral, VsoeDeferral
+      # field :vsoe_permit_discount, VsoePermitDiscount
+      # field :vsoe_sop_group, VsoeSopGroup
 
       attr_reader :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/kit_item.rb
+++ b/lib/netsuite/records/kit_item.rb
@@ -1,7 +1,67 @@
 module NetSuite
   module Records
-    class KitItem < InventoryItem
-      
+    class KitItem
+      include Support::Fields
+      include Support::RecordRefs
+      include Support::Records
+      include Support::Actions
+      include Namespaces::ListAcct
+
+      actions :get, :get_list, :add, :delete, :search, :update, :upsert
+
+      fields :auto_lead_time, :auto_preferred_stock_level, :auto_reorder_point, :available_to_partners, :average_cost,
+        :copy_description, :cost, :cost_estimate, :cost_estimate_type, :cost_estimate_units, :cost_units, :costing_method,
+        :costing_method_display, :country_of_manufacture, :created_date, :currency, :date_converted_to_inv,
+        :default_return_cost, :demand_modifier, :display_name, :dont_show_price, :enforce_min_qty_internally,
+        :exclude_from_sitemap, :featured_description, :fixed_lot_size, :handling_cost, :handling_cost_units, :include_children,
+        :is_donation_item, :is_drop_ship_item, :is_gco_compliant, :is_inactive, :is_online, :is_special_order_item, :is_taxable,
+        :item_id, :last_modified_date, :last_purchase_price, :lead_time, :manufacturer, :manufacturer_addr1, :manufacturer_city,
+        :manufacturer_state, :manufacturer_tariff, :manufacturer_tax_id, :manufacturer_zip, :match_bill_to_receipt,
+        :matrix_type, :max_donation_amount, :meta_tag_html, :minimum_quantity, :minimum_quantity_units, :mpn,
+        :mult_manufacture_addr, :nex_tag_category, :no_price_message, :offer_support, :on_hand_value_mli, :on_special,
+        :original_item_subtype, :original_item_type, :out_of_stock_behavior, :out_of_stock_message,
+        :overall_quantity_pricing_type, :page_title, :preference_criterion, :preferred_stock_level, :preferred_stock_level_days,
+        :preferred_stock_level_units, :prices_include_tax, :producer, :purchase_description, :quantity_available,
+        :quantity_available_units, :quantity_back_ordered, :quantity_committed, :quantity_committed_units, :quantity_on_hand,
+        :quantity_on_hand_units, :quantity_on_order, :quantity_on_order_units, :quantity_reorder_units, :rate,
+        :related_items_description, :reorder_multiple, :reorder_point, :reorder_point_units, :safety_stock_level,
+        :safety_stock_level_days, :safety_stock_level_units, :sales_description, :schedule_b_code, :schedule_b_number,
+        :schedule_b_quantity, :search_keywords, :seasonal_demand, :ship_individually, :shipping_cost, :shipping_cost_units,
+        :shopping_dot_com_category, :shopzilla_category_id, :show_default_donation_amount, :sitemap_priority,
+        :specials_description, :stock_description, :store_description, :store_detailed_description, :store_display_name,
+        :total_value, :track_landed_cost, :transfer_price, :upc_code, :url_component, :use_bins, :use_marginal_rates,
+        :vendor_name, :vsoe_deferral, :vsoe_delivered, :vsoe_permit_discount, :vsoe_price, :weight, :weight_unit, :weight_units
+
+      record_refs :alternate_demand_source_item, :asset_account, :bill_exch_rate_variance_acct, :bill_price_variance_acct,
+        :bill_qty_variance_acct, :billing_schedule, :cogs_account, :cost_category, :custom_form, :deferred_revenue_account,
+        :demand_source, :department, :expense_account, :gain_loss_account, :income_account, :issue_product, :klass, :location,
+        :parent, :preferred_location, :pricing_group, :purchase_price_variance_acct, :purchase_tax_code, :purchase_unit,
+        :quantity_pricing_schedule, :rev_rec_schedule, :sale_unit, :sales_tax_code, :ship_package, :soft_descriptor,
+        :stock_unit, :store_display_image, :store_display_thumbnail, :store_item_template, :supply_lot_sizing_method,
+        :supply_replenishment_method, :supply_type, :tax_schedule, :units_type, :vendor
+
+      field :pricing_matrix, PricingMatrix
+      field :custom_field_list, CustomFieldList
+      field :bin_number_list, BinNumberList
+      field :locations_list, LocationsList
+      field :matrix_option_list, MatrixOptionList
+      field :subsidiary_list, RecordRefList
+
+      # for Assembly/Kit
+      field :member_list, MemberList
+
+      attr_reader :internal_id
+      attr_accessor :external_id
+
+      def initialize(attributes = {})
+        @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
+        @external_id = attributes.delete(:external_id) || attributes.delete(:@external_id)
+        initialize_from_attributes_hash(attributes)
+      end
+
+      def self.search_class_name
+        "Item"
+      end
     end
   end
 end

--- a/lib/netsuite/records/kit_item.rb
+++ b/lib/netsuite/records/kit_item.rb
@@ -23,10 +23,10 @@ module NetSuite
         :vsoe_price, :weight
 
       record_refs :billing_schedule, :custom_form, :default_item_ship_method, :deferred_revenue_account, :department,
-        :income_account, :issue_product, :item_revenue_category, :location, :parent, :pricing_group, :quantity_pricing_schedule,
-        :revenue_allocation_group, :revenue_recognition_rule, :rev_rec_schedule, :sales_tax_code, :schedule_b_code,
-        :ship_package, :soft_descriptor, :store_display_image, :store_display_thumbnail, :store_item_template, :tax_schedule,
-        :weight_unit
+        :income_account, :issue_product, :item_revenue_category, :klass, :location, :parent, :pricing_group,
+        :quantity_pricing_schedule, :revenue_allocation_group, :revenue_recognition_rule, :rev_rec_schedule, :sales_tax_code,
+        :schedule_b_code, :ship_package, :soft_descriptor, :store_display_image, :store_display_thumbnail, :store_item_template,
+        :tax_schedule, :weight_unit
 
       field :custom_field_list, CustomFieldList
       field :pricing_matrix, PricingMatrix

--- a/spec/netsuite/records/kit_item_spec.rb
+++ b/spec/netsuite/records/kit_item_spec.rb
@@ -5,27 +5,7 @@ describe NetSuite::Records::KitItem do
 
   it 'has all the right fields' do
     [
-      :auto_lead_time, :auto_preferred_stock_level, :auto_reorder_point, :available_to_partners, :average_cost, :copy_description,
-      :cost, :cost_estimate, :cost_estimate_type, :cost_estimate_units, :cost_units, :costing_method, :costing_method_display,
-      :country_of_manufacture, :created_date, :currency, :date_converted_to_inv, :default_return_cost, :demand_modifier,
-      :display_name, :dont_show_price, :enforce_min_qty_internally, :exclude_from_sitemap, :featured_description, :fixed_lot_size,
-      :handling_cost, :handling_cost_units, :include_children, :is_donation_item, :is_drop_ship_item, :is_gco_compliant,
-      :is_inactive, :is_online, :is_special_order_item, :is_taxable, :item_id, :last_modified_date, :last_purchase_price,
-      :lead_time, :manufacturer, :manufacturer_addr1, :manufacturer_city, :manufacturer_state, :manufacturer_tariff,
-      :manufacturer_tax_id, :manufacturer_zip, :match_bill_to_receipt, :matrix_type, :max_donation_amount, :meta_tag_html,
-      :minimum_quantity, :minimum_quantity_units, :mpn, :mult_manufacture_addr, :nex_tag_category, :no_price_message,
-      :offer_support, :on_hand_value_mli, :on_special, :original_item_subtype, :original_item_type, :out_of_stock_behavior,
-      :out_of_stock_message, :overall_quantity_pricing_type, :page_title, :preference_criterion, :preferred_stock_level,
-      :preferred_stock_level_days, :preferred_stock_level_units, :prices_include_tax, :producer, :purchase_description,
-      :quantity_available, :quantity_available_units, :quantity_back_ordered, :quantity_committed, :quantity_committed_units,
-      :quantity_on_hand, :quantity_on_hand_units, :quantity_on_order, :quantity_on_order_units, :quantity_reorder_units, :rate,
-      :related_items_description, :reorder_multiple, :reorder_point, :reorder_point_units, :safety_stock_level,
-      :safety_stock_level_days, :safety_stock_level_units, :sales_description, :schedule_b_code, :schedule_b_number,
-      :schedule_b_quantity, :search_keywords, :seasonal_demand, :ship_individually, :shipping_cost, :shipping_cost_units,
-      :shopping_dot_com_category, :shopzilla_category_id, :show_default_donation_amount, :sitemap_priority, :specials_description,
-      :stock_description, :store_description, :store_detailed_description, :store_display_name, :total_value, :track_landed_cost,
-      :transfer_price, :upc_code, :url_component, :use_bins, :use_marginal_rates, :vendor_name, :vsoe_deferral, :vsoe_delivered,
-      :vsoe_permit_discount, :vsoe_price, :weight, :weight_unit, :weight_units
+      :available_to_partners, :cost_estimate, :created_date, :defer_rev_rec, :description, :display_name, :dont_show_price, :enforce_min_qty_internally, :exclude_from_sitemap, :featured_description, :handling_cost, :hazmat_hazard_class, :hazmat_id, :hazmat_item_units, :hazmat_item_units_qty, :hazmat_shipping_name, :include_children, :is_donation_item, :is_fulfillable, :is_gco_compliant, :is_hazmat_item, :is_inactive, :is_online, :is_taxable, :item_id, :last_modified_date, :manufacturer, :manufactureraddr1, :manufacturer_city, :manufacturer_state, :manufacturer_tariff, :manufacturer_tax_id, :manufacturer_zip, :max_donation_amount, :meta_tag_html, :minimum_quantity, :mpn, :mult_manufacture_addr, :nex_tag_category, :no_price_message, :offer_support, :on_special, :out_of_stock_message, :page_title, :prices_include_tax, :print_items, :producer, :rate, :related_items_description, :schedule_b_number, :schedule_b_quantity, :search_keywords, :ship_individually, :shipping_cost, :shopping_dot_com_category, :shopzilla_category_id, :show_default_donation_amount, :specials_description, :stock_description, :store_description, :store_detailed_description, :store_display_name, :upc_code, :url_component, :use_marginal_rates, :vsoe_delivered, :vsoe_price, :weight
     ].each do |field|
       expect(item).to have_field(field)
     end
@@ -33,81 +13,21 @@ describe NetSuite::Records::KitItem do
 
   it 'has all the right record refs' do
     [
-      :alternate_demand_source_item, :asset_account, :bill_exch_rate_variance_acct, :bill_price_variance_acct, :bill_qty_variance_acct, :billing_schedule, :cogs_account, :cost_category, :custom_form, :deferred_revenue_account, :demand_source, :department, :expense_account, :gain_loss_account, :income_account, :issue_product, :klass, :location, :parent, :preferred_location, :pricing_group, :purchase_price_variance_acct, :purchase_tax_code, :purchase_unit, :quantity_pricing_schedule, :rev_rec_schedule, :sale_unit, :sales_tax_code, :ship_package, :soft_descriptor, :stock_unit, :store_display_image, :store_display_thumbnail, :store_item_template, :supply_lot_sizing_method, :supply_replenishment_method, :supply_type, :tax_schedule, :units_type, :vendor
+      :billing_schedule, :custom_form, :default_item_ship_method, :deferred_revenue_account, :department, :income_account, :issue_product, :item_revenue_category, :location, :parent, :pricing_group, :quantity_pricing_schedule, :revenue_allocation_group, :revenue_recognition_rule, :rev_rec_schedule, :sales_tax_code, :schedule_b_code, :ship_package, :soft_descriptor, :store_display_image, :store_display_thumbnail, :store_item_template, :tax_schedule, :weight_unit
     ].each do |record_ref|
       expect(item).to have_record_ref(record_ref)
     end
   end
 
-  describe '#pricing_matrix' do
-    it 'can be set from attributes'
-    it 'can be set from a PricingMatrix object'
-  end
-
-  describe '#product_feed_list' do
-    it 'can be set from attributes'
-    it 'can be set from a ProductFeedList object'
-  end
-
-  describe '#subsidiary_list' do
-    it 'can be set from attributes'
-    it 'can be set from a RecordRefList object'
-  end
-
-  describe '#item_options_list' do
-    it 'can be set from attributes'
-    it 'can be set from a ItemOptionsList object'
-  end
-
-  describe '#item_vendor_list' do
-    it 'can be set from attributes'
-    it 'can be set from an ItemVendorList object'
-  end
-
-  describe '#site_category_list' do
-    it 'can be set from attributes'
-    it 'can be set from a SiteCategoryList object'
-  end
-
-  describe '#translations_list' do
-    it 'can be set from attributes'
-    it 'can be set from a TranslationList object'
-  end
-
-  describe '#bin_number_list' do
-    it 'can be set from attributes'
-    it 'can be set from an KitItemBinNumberList object'
-  end
-
-  describe '#locations_list' do
-    it 'can be set from attributes'
-    it 'can be set from an KitItemLocationsList object'
-  end
-
-  describe '#matrix_option_list' do
-    it 'can be set from attributes'
-    it 'can be set from a MatrixOptionList object'
-  end
-
-  describe '#presentation_item_list' do
-    it 'can be set from attributes'
-    it 'can be set from a PresentationItemList object'
-  end
-
-  describe '#custom_field_list' do
-    it 'can be set from attributes'
-    it 'can be set from a CustomFieldList object'
-  end
-
   describe '.get' do
     context 'when the response is successful' do
-      let(:response) { NetSuite::Response.new(:success => true, :body => { :cost => 100 }) }
+      let(:response) { NetSuite::Response.new(:success => true, :body => { :item_id => "Item100" }) }
 
       it 'returns a KitItem instance populated with the data from the response object' do
         expect(NetSuite::Actions::Get).to receive(:call).with([NetSuite::Records::KitItem, {:external_id => 1}], {}).and_return(response)
         item = NetSuite::Records::KitItem.get(:external_id => 1)
         expect(item).to be_kind_of(NetSuite::Records::KitItem)
-        expect(item.cost).to eql(100)
+        expect(item.item_id).to eql("Item100")
       end
     end
 
@@ -125,7 +45,7 @@ describe NetSuite::Records::KitItem do
   end
 
   describe '#add' do
-    let(:item) { NetSuite::Records::KitItem.new(:cost => 100, :is_inactive => false) }
+    let(:item) { NetSuite::Records::KitItem.new(:item_id => "Item100", :is_inactive => false) }
 
     context 'when the response is successful' do
       let(:response) { NetSuite::Response.new(:success => true, :body => { :internal_id => '1' }) }
@@ -176,12 +96,12 @@ describe NetSuite::Records::KitItem do
 
   describe '#to_record' do
     before do
-      item.cost = 100
+      item.item_id = "Item100"
       item.is_inactive = false
     end
     it 'can represent itself as a SOAP record' do
       record = {
-        'listAcct:cost'       => 100,
+        'listAcct:itemId'       => "Item100",
         'listAcct:isInactive' => false
       }
       expect(item.to_record).to eql(record)

--- a/spec/netsuite/records/kit_item_spec.rb
+++ b/spec/netsuite/records/kit_item_spec.rb
@@ -1,0 +1,197 @@
+require 'spec_helper'
+
+describe NetSuite::Records::KitItem do
+  let(:item) { NetSuite::Records::KitItem.new }
+
+  it 'has all the right fields' do
+    [
+      :auto_lead_time, :auto_preferred_stock_level, :auto_reorder_point, :available_to_partners, :average_cost, :copy_description,
+      :cost, :cost_estimate, :cost_estimate_type, :cost_estimate_units, :cost_units, :costing_method, :costing_method_display,
+      :country_of_manufacture, :created_date, :currency, :date_converted_to_inv, :default_return_cost, :demand_modifier,
+      :display_name, :dont_show_price, :enforce_min_qty_internally, :exclude_from_sitemap, :featured_description, :fixed_lot_size,
+      :handling_cost, :handling_cost_units, :include_children, :is_donation_item, :is_drop_ship_item, :is_gco_compliant,
+      :is_inactive, :is_online, :is_special_order_item, :is_taxable, :item_id, :last_modified_date, :last_purchase_price,
+      :lead_time, :manufacturer, :manufacturer_addr1, :manufacturer_city, :manufacturer_state, :manufacturer_tariff,
+      :manufacturer_tax_id, :manufacturer_zip, :match_bill_to_receipt, :matrix_type, :max_donation_amount, :meta_tag_html,
+      :minimum_quantity, :minimum_quantity_units, :mpn, :mult_manufacture_addr, :nex_tag_category, :no_price_message,
+      :offer_support, :on_hand_value_mli, :on_special, :original_item_subtype, :original_item_type, :out_of_stock_behavior,
+      :out_of_stock_message, :overall_quantity_pricing_type, :page_title, :preference_criterion, :preferred_stock_level,
+      :preferred_stock_level_days, :preferred_stock_level_units, :prices_include_tax, :producer, :purchase_description,
+      :quantity_available, :quantity_available_units, :quantity_back_ordered, :quantity_committed, :quantity_committed_units,
+      :quantity_on_hand, :quantity_on_hand_units, :quantity_on_order, :quantity_on_order_units, :quantity_reorder_units, :rate,
+      :related_items_description, :reorder_multiple, :reorder_point, :reorder_point_units, :safety_stock_level,
+      :safety_stock_level_days, :safety_stock_level_units, :sales_description, :schedule_b_code, :schedule_b_number,
+      :schedule_b_quantity, :search_keywords, :seasonal_demand, :ship_individually, :shipping_cost, :shipping_cost_units,
+      :shopping_dot_com_category, :shopzilla_category_id, :show_default_donation_amount, :sitemap_priority, :specials_description,
+      :stock_description, :store_description, :store_detailed_description, :store_display_name, :total_value, :track_landed_cost,
+      :transfer_price, :upc_code, :url_component, :use_bins, :use_marginal_rates, :vendor_name, :vsoe_deferral, :vsoe_delivered,
+      :vsoe_permit_discount, :vsoe_price, :weight, :weight_unit, :weight_units
+    ].each do |field|
+      expect(item).to have_field(field)
+    end
+  end
+
+  it 'has all the right record refs' do
+    [
+      :alternate_demand_source_item, :asset_account, :bill_exch_rate_variance_acct, :bill_price_variance_acct, :bill_qty_variance_acct, :billing_schedule, :cogs_account, :cost_category, :custom_form, :deferred_revenue_account, :demand_source, :department, :expense_account, :gain_loss_account, :income_account, :issue_product, :klass, :location, :parent, :preferred_location, :pricing_group, :purchase_price_variance_acct, :purchase_tax_code, :purchase_unit, :quantity_pricing_schedule, :rev_rec_schedule, :sale_unit, :sales_tax_code, :ship_package, :soft_descriptor, :stock_unit, :store_display_image, :store_display_thumbnail, :store_item_template, :supply_lot_sizing_method, :supply_replenishment_method, :supply_type, :tax_schedule, :units_type, :vendor
+    ].each do |record_ref|
+      expect(item).to have_record_ref(record_ref)
+    end
+  end
+
+  describe '#pricing_matrix' do
+    it 'can be set from attributes'
+    it 'can be set from a PricingMatrix object'
+  end
+
+  describe '#product_feed_list' do
+    it 'can be set from attributes'
+    it 'can be set from a ProductFeedList object'
+  end
+
+  describe '#subsidiary_list' do
+    it 'can be set from attributes'
+    it 'can be set from a RecordRefList object'
+  end
+
+  describe '#item_options_list' do
+    it 'can be set from attributes'
+    it 'can be set from a ItemOptionsList object'
+  end
+
+  describe '#item_vendor_list' do
+    it 'can be set from attributes'
+    it 'can be set from an ItemVendorList object'
+  end
+
+  describe '#site_category_list' do
+    it 'can be set from attributes'
+    it 'can be set from a SiteCategoryList object'
+  end
+
+  describe '#translations_list' do
+    it 'can be set from attributes'
+    it 'can be set from a TranslationList object'
+  end
+
+  describe '#bin_number_list' do
+    it 'can be set from attributes'
+    it 'can be set from an KitItemBinNumberList object'
+  end
+
+  describe '#locations_list' do
+    it 'can be set from attributes'
+    it 'can be set from an KitItemLocationsList object'
+  end
+
+  describe '#matrix_option_list' do
+    it 'can be set from attributes'
+    it 'can be set from a MatrixOptionList object'
+  end
+
+  describe '#presentation_item_list' do
+    it 'can be set from attributes'
+    it 'can be set from a PresentationItemList object'
+  end
+
+  describe '#custom_field_list' do
+    it 'can be set from attributes'
+    it 'can be set from a CustomFieldList object'
+  end
+
+  describe '.get' do
+    context 'when the response is successful' do
+      let(:response) { NetSuite::Response.new(:success => true, :body => { :cost => 100 }) }
+
+      it 'returns a KitItem instance populated with the data from the response object' do
+        expect(NetSuite::Actions::Get).to receive(:call).with([NetSuite::Records::KitItem, {:external_id => 1}], {}).and_return(response)
+        item = NetSuite::Records::KitItem.get(:external_id => 1)
+        expect(item).to be_kind_of(NetSuite::Records::KitItem)
+        expect(item.cost).to eql(100)
+      end
+    end
+
+    context 'when the response is unsuccessful' do
+      let(:response) { NetSuite::Response.new(:success => false, :body => {}) }
+
+      it 'raises a RecordNotFound exception' do
+        expect(NetSuite::Actions::Get).to receive(:call).with([NetSuite::Records::KitItem, {:external_id => 1}], {}).and_return(response)
+        expect {
+          NetSuite::Records::KitItem.get(:external_id => 1)
+        }.to raise_error(NetSuite::RecordNotFound,
+          /NetSuite::Records::KitItem with OPTIONS=(.*) could not be found/)
+      end
+    end
+  end
+
+  describe '#add' do
+    let(:item) { NetSuite::Records::KitItem.new(:cost => 100, :is_inactive => false) }
+
+    context 'when the response is successful' do
+      let(:response) { NetSuite::Response.new(:success => true, :body => { :internal_id => '1' }) }
+
+      it 'returns true' do
+        expect(NetSuite::Actions::Add).to receive(:call).
+            with([item], {}).
+            and_return(response)
+        expect(item.add).to be_truthy
+      end
+    end
+
+    context 'when the response is unsuccessful' do
+      let(:response) { NetSuite::Response.new(:success => false, :body => {}) }
+
+      it 'returns false' do
+        expect(NetSuite::Actions::Add).to receive(:call).
+            with([item], {}).
+            and_return(response)
+        expect(item.add).to be_falsey
+      end
+    end
+  end
+
+  describe '#delete' do
+    context 'when the response is successful' do
+      let(:response) { NetSuite::Response.new(:success => true, :body => { :internal_id => '1' }) }
+
+      it 'returns true' do
+        expect(NetSuite::Actions::Delete).to receive(:call).
+            with([item], {}).
+            and_return(response)
+        expect(item.delete).to be_truthy
+      end
+    end
+
+    context 'when the response is unsuccessful' do
+      let(:response) { NetSuite::Response.new(:success => false, :body => {}) }
+
+      it 'returns false' do
+        expect(NetSuite::Actions::Delete).to receive(:call).
+            with([item], {}).
+            and_return(response)
+        expect(item.delete).to be_falsey
+      end
+    end
+  end
+
+  describe '#to_record' do
+    before do
+      item.cost = 100
+      item.is_inactive = false
+    end
+    it 'can represent itself as a SOAP record' do
+      record = {
+        'listAcct:cost'       => 100,
+        'listAcct:isInactive' => false
+      }
+      expect(item.to_record).to eql(record)
+    end
+  end
+
+  describe '#record_type' do
+    it 'returns a string representation of the SOAP type' do
+      expect(item.record_type).to eql('listAcct:KitItem')
+    end
+  end
+
+end


### PR DESCRIPTION
Currently, the KitItem class subclasses InventoryItem, but it has a different schema and I'm not able to access most of it's attributes:

```
2.1.6 > item = NetSuite::Records::KitItem.get(2110)
 => #<NetSuite::Records::KitItem:0x007fac688cefd0 @internal_id="2110", @external_id=nil, @attributes={:klass=>#<NetSuite::Records::RecordRef:0x007fac688ce850 @internal_id="11", @external_id=nil, @type=nil, @attributes={:name=>"GriefShare : EN"}>}>
2.1.6 > item.internal_id
 => "2110"
2.1.6 > item.created_date
 => nil
2.1.6 > item.display_name
 => nil
```

I reimplemented KitItem using it's fields and record_refs and added it's own specs, very similar to InventoryItem's. How does this look?