### PR TITLE
Search joins 4 invoice

### DIFF
--- a/lib/netsuite/records/invoice.rb
+++ b/lib/netsuite/records/invoice.rb
@@ -48,6 +48,7 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
+      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/spec/netsuite/records/invoice_spec.rb
+++ b/spec/netsuite/records/invoice_spec.rb
@@ -212,6 +212,51 @@ describe NetSuite::Records::Invoice do
     end
   end
 
+  describe '.search' do
+    context 'when the response is successful' do
+      let(:response) do
+        NetSuite::Response.new(
+          :success => true,
+          :body => {
+            :status => { :@is_success => 'true' },
+            :total_records => '1',
+            :search_row_list => {
+              :search_row => {
+                :basic => {
+                  :alt_name => {:search_value=>'A Awesome Name'},
+                  :"@xmlns:platform_common"=>'urn:common_2012_1.platform.webservices.netsuite.com'},
+                  :"@xsi:type" => 'listRel:ItemSearchRow'
+                }
+              }
+            }
+          )
+      end
+
+      it 'returns an Invoice instance populated with the data from the response object' do
+        allow(NetSuite::Actions::Search).to receive(:call).and_return(response)
+
+        invoice = NetSuite::Records::Invoice.search(
+          criteria: {
+            basic: [
+              {
+                field: 'type',
+                operator: 'anyOf',
+                type: 'SearchEnumMultiSelectField',
+                value: ['_invoice']
+              }
+            ]
+          },
+          columns: {
+            'tranSales:basic' => [
+              'platformCommon:internalId/' => {}
+            ]
+          }
+        ).results[0]
+        expect(invoice).to be_kind_of(NetSuite::Records::Invoice)
+      end
+    end
+  end
+
   describe '.initialize' do
     context 'when the request is successful' do
       it 'returns an initialized invoice from the customer entity' do


### PR DESCRIPTION
Hey Michael,

I hope you're not sick of my PRs just yet 😜

I was getting an error when I used the basic column search for Invoices:

```
NoMethodError: 
undefined method `search_joins=' for #<NetSuite::Records::Invoice:0x007fb672481e78>
```

I wrote a little test for it as well, which I can put into a shared example for similar records if you think that's a good idea.

Thanks 