### PR TITLE
Record ref doesn't pick up the internal_id

### DIFF
--- a/lib/netsuite/support/search_result.rb
+++ b/lib/netsuite/support/search_result.rb
@@ -20,7 +20,7 @@ module NetSuite
       def initialize(response, result_class)
         @result_class = result_class
         @response = response
-        
+
         @total_records = response.body[:total_records].to_i
         @total_pages = response.body[:total_pages].to_i
         @current_page = response.body[:page_index].to_i
@@ -50,10 +50,10 @@ module NetSuite
                 record[search_group].each_pair do |k, v|
                   # all return values are wrapped in a <SearchValue/>
                   # extract the value from <SearchValue/> to make results easier to work with
-
                   if v.is_a?(Hash) && v.has_key?(:search_value)
-                    # search return values that are just internalIds are stored as attributes on the searchValue element
-                    if v[:search_value].is_a?(Hash) && v[:search_value].has_key?(:'@internal_id')
+                    # only turn this: :internal_id=>{:search_value=>{:@internal_id=>"5"}}
+                    # into this: :internal_id=> "5"
+                    if k == :internal_id && v[:search_value].is_a?(Hash) && v[:search_value].has_key?(:'@internal_id')
                       record[search_group][k] = v[:search_value][:'@internal_id']
                     else
                       record[search_group][k] = v[:search_value]

--- a/spec/netsuite/support/search_result_spec.rb
+++ b/spec/netsuite/support/search_result_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe NetSuite::Support::SearchResult do
+  describe '#initialize' do
+    context 'when it is basic column search' do
+      let(:response) do
+        NetSuite::Response.new(
+          :success=>true,
+          :header=> {
+            :ns_id=>"WEBSER",
+            :"@xmlns:platform_msgs"=>"urn:messages_2016_1.platform.webservices.netsuite.com"
+          },
+          :body => {
+            :status => {:@is_success=>"true"},
+            :total_records=>"1",
+            :page_size=>"100",
+            :total_pages=>"1",
+            :page_index=>"1",
+            :search_id=>"WEBSER",
+            :search_row_list=>{
+              :search_row=>[
+                {:basic=>{
+                  :amount_paid=>{:search_value=>"0.0"},
+                  :amount_remaining=>{:search_value=>"6030.0"},
+                  :date_created=>{:search_value=> Time.new(2013)},
+                  :entity=>{:search_value=>{:@internal_id=>"11"}},
+                  :internal_id=>{:search_value=>{:@internal_id=>"5"}},
+                  :total=>{:search_value=>"6030.0"},
+                  :tran_date=>{:search_value=> Time.new(2013)},
+                  :tran_id=>{:search_value=>"2"},
+                  :transaction_number=>{:search_value=>"2"},
+                  :"@xmlns:platform_common"=>"urn:common_2016_1.platform.webservices.netsuite.com"},
+                  :"@xmlns:tran_sales"=>"urn:sales_2016_1.transactions.webservices.netsuite.com",
+                  :"@xsi:type"=>"tranSales:TransactionSearchRow"
+                }
+              ]
+            }
+          }
+        )
+      end
+
+      let(:result) do
+        NetSuite::Support::SearchResult.new(
+          response,
+          NetSuite::Records::Invoice
+        ).results.first
+      end
+
+      it 'passes the internal_id into record_ref correctly' do
+        expect(result.entity.internal_id.to_i).to eq(11)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi Michael,

I was having a problem with record_ref and I figured it's happening because `RecordRef` expects the hash attribute to be something like this: `{internal_id: "44"}` but in the search result if you passed something like:

```
{
  :entity=>{:search_value=>{:@internal_id=>"11"}},
  :internal_id=>{:search_value=>{:@internal_id=>"5"}}
}

# it would turn it into:
{
  :entity=>"11",
  :internal_id=>"5"
}

# instead of this:
{
  :entity=>{:@internal_id=>"11"},
  :internal_id=>"5"}
}
```

So I added `k == :internal_id` in line 56. Hope my implementation is ok.

Cheers,
