### PR TITLE
Refactor list objects to use Support::Sublist

### DIFF
--- a/lib/netsuite/records/base_ref_list.rb
+++ b/lib/netsuite/records/base_ref_list.rb
@@ -2,31 +2,15 @@
 
 module NetSuite
   module Records
-    class BaseRefList
-      include Support::Fields
+    class BaseRefList < Support::Sublist
       include Support::Actions
       include Namespaces::PlatformCore
 
       actions :get_select_value
 
-      fields :base_ref
+      sublist :base_ref, RecordRef
 
-      def initialize(attrs = {})
-        initialize_from_attributes_hash(attrs)
-      end
-
-      def base_ref=(refs)
-        case refs
-        when Hash
-          self.base_ref << RecordRef.new(refs)
-        when Array
-          refs.each { |ref| self.base_ref << RecordRef.new(ref) }
-        end
-      end
-
-      def base_ref
-        @base_ref ||= []
-      end
+      alias :base_refs :base_ref
 
     end
   end

--- a/lib/netsuite/records/billing_schedule_milestone_list.rb
+++ b/lib/netsuite/records/billing_schedule_milestone_list.rb
@@ -1,31 +1,12 @@
 module NetSuite
   module Records
-    class BillingScheduleMilestoneList
-      include Support::Fields
+    class BillingScheduleMilestoneList < Support::Sublist
       include Namespaces::ListAcct
 
-      fields :billing_schedule_milestone
+      sublist :billing_schedule_milestone, BillingScheduleMilestone
 
-      def initialize(attributes = {})
-        initialize_from_attributes_hash(attributes)
-      end
-
-      def milestone=(milestones)
-        case milestones
-        when Hash
-          self.milestones << BillingScheduleMilestone.new(milestones)
-        when Array
-          milestones.each { |milestone| self.milestones << BillingScheduleMilestone.new(milestone) }
-        end
-      end
-
-      def milestones
-        @milestones ||= []
-      end
-
-      def to_record
-        { "#{record_namespace}:billingScheduleMilestone" => milestones.map(&:to_record) }
-      end
+      alias :milestones :billing_schedule_milestone
+      alias :milestone= :billing_schedule_milestone=
 
     end
   end

--- a/lib/netsuite/records/billing_schedule_recurrence_list.rb
+++ b/lib/netsuite/records/billing_schedule_recurrence_list.rb
@@ -1,31 +1,12 @@
 module NetSuite
   module Records
-    class BillingScheduleRecurrenceList
-      include Support::Fields
+    class BillingScheduleRecurrenceList < Support::Sublist
       include Namespaces::ListAcct
 
-      fields :billing_schedule_recurrence
+      sublist :billing_schedule_recurrence, BillingScheduleRecurrence
 
-      def initialize(attributes = {})
-        initialize_from_attributes_hash(attributes)
-      end
-
-      def recurrence=(recurrences)
-        case recurrences
-        when Hash
-          self.recurrences << BillingScheduleRecurrence.new(recurrences)
-        when Array
-          recurrences.each { |recurrence| self.recurrences << BillingScheduleRecurrence.new(recurrence) }
-        end
-      end
-
-      def recurrences
-        @recurrences ||= []
-      end
-
-      def to_record
-        { "#{record_namespace}:billingScheduleRecurrence" => recurrences.map(&:to_record) }
-      end
+      alias :recurrences :billing_schedule_recurrence
+      alias :recurrence= :billing_schedule_recurrence=
 
     end
   end

--- a/lib/netsuite/records/bin_number_list.rb
+++ b/lib/netsuite/records/bin_number_list.rb
@@ -2,7 +2,7 @@ module NetSuite
   module Records
     # TODO this is fairly messy: shouldn't mix multiple classes in one file
     # might be possible to trash the GenericField as well
-    
+
     class GenericField
       include Support::Attributes
       include Support::Fields
@@ -13,36 +13,18 @@ module NetSuite
     end
 
     class BinNumber < GenericField
+      include Support::Records
 
     end
 
-    class BinNumberList
-      include Support::Fields
+    class BinNumberList < Support::Sublist
       include Namespaces::PlatformCore
       # include Namespaces::ListAcct
 
-      fields :bin_number
+      sublist :bin_number, BinNumber
 
-      def initialize(attributes = {})
-        initialize_from_attributes_hash(attributes)
-      end
+      alias :bin_numbers :bin_number
 
-      def bin_number=(items)
-        case items
-        when Hash
-          self.bin_numbers << BinNumber.new(items)
-        when Array
-          items.each { |item| self.bin_numbers << BinNumber.new(item) }
-        end
-      end
-
-      def bin_numbers
-        @bin_numbers ||= []
-      end
-
-      def to_record
-        { "#{record_namespace}:item" => bin_numbers.map(&:to_record) }
-      end
     end
   end
 end

--- a/lib/netsuite/records/cash_refund_item_list.rb
+++ b/lib/netsuite/records/cash_refund_item_list.rb
@@ -1,31 +1,11 @@
 module NetSuite
   module Records
-    class CashRefundItemList
-      include Support::Fields
+    class CashRefundItemList < Support::Sublist
       include Namespaces::TranCust
 
-      fields :item
+      sublist :item, CashRefundItem
 
-      def initialize(attributes = {})
-        initialize_from_attributes_hash(attributes)
-      end
-
-      def item=(items)
-        case items
-        when Hash
-          self.items << CashRefundItem.new(items)
-        when Array
-          items.each { |item| self.items << CashRefundItem.new(item) }
-        end
-      end
-
-      def items
-        @items ||= []
-      end
-
-      def to_record
-        { "#{record_namespace}:item" => items.map(&:to_record) }
-      end
+      alias :items :item
 
     end
   end

--- a/lib/netsuite/records/cash_sale_item_list.rb
+++ b/lib/netsuite/records/cash_sale_item_list.rb
@@ -1,24 +1,12 @@
 module NetSuite
   module Records
-    class CashSaleItemList
+    class CashSaleItemList < Support::Sublist
       include Namespaces::TranSales
 
-      def initialize(attributes = {})
-        case attributes[:item]
-        when Hash
-          items << CashSaleItem.new(attributes[:item])
-        when Array
-          attributes[:item].each { |item| items << CashSaleItem.new(item) }
-        end
-      end
+      sublist :item, CashSaleItem
 
-      def items
-        @items ||= []
-      end
+      alias :items :item
 
-      def to_record
-        { "#{record_namespace}:item" => items.map(&:to_record) }
-      end
     end
   end
 end

--- a/lib/netsuite/records/customer_payment_apply_list.rb
+++ b/lib/netsuite/records/customer_payment_apply_list.rb
@@ -1,31 +1,12 @@
 module NetSuite
   module Records
-    class CustomerPaymentApplyList
-      include Support::Fields
+    class CustomerPaymentApplyList < Support::Sublist
       include Namespaces::TranCust
 
-      fields :apply
+      sublist :apply, CustomerPaymentApply
 
-      def initialize(attributes = {})
-        initialize_from_attributes_hash(attributes)
-      end
+      alias :applies :apply
 
-      def apply=(applies)
-        case applies
-          when Hash
-            self.applies << CustomerPaymentApply.new(applies)
-          when Array
-            applies.each { |apply| self.applies << CustomerPaymentApply.new(apply) }
-        end
-      end
-
-      def applies
-        @applies ||= []
-      end
-
-      def to_record
-        { "#{record_namespace}:apply" => applies.map(&:to_record) }
-      end
     end
   end
 end

--- a/lib/netsuite/records/customer_refund_apply_list.rb
+++ b/lib/netsuite/records/customer_refund_apply_list.rb
@@ -1,30 +1,13 @@
 module NetSuite
   module Records
-    class CustomerRefundApplyList
+    class CustomerRefundApplyList < Support::Sublist
       include Namespaces::TranCust
-
-      # TODO should use new sublist implementation
 
       attr_accessor :replace_all
 
-      def initialize(attributes = {})
-        case attributes[:apply]
-        when Hash
-          applies << CustomerRefundApply.new(attributes[:apply])
-        when Array
-          attributes[:apply].each { |apply| applies << CustomerRefundApply.new(apply) }
-        end
-      end
+      sublist :apply, CustomerRefundApply
 
-      def applies
-        @applies ||= []
-      end
-
-      def to_record
-        rec = { "#{record_namespace}:apply" => applies.map(&:to_record) }
-        rec[:@replaceAll] = @replace_all unless @replace_all.nil?
-        rec
-      end
+      alias :applies :apply
 
     end
   end

--- a/lib/netsuite/records/inventory_transfer_inventory_list.rb
+++ b/lib/netsuite/records/inventory_transfer_inventory_list.rb
@@ -1,33 +1,12 @@
 module NetSuite
   module Records
-    class InventoryTransferInventoryList
+    class InventoryTransferInventoryList < Support::Sublist
       include Support::RecordRefs
       include Support::Records
-      include Support::Fields
       include Namespaces::TranInvt
 
-      fields :inventory
+      sublist :inventory, InventoryTransferInventory
 
-      def initialize(attributes = {})
-        initialize_from_attributes_hash(attributes)
-      end
-
-      def inventory=(items)
-        case items
-        when Hash
-          self.inventory << InventoryTransferInventory.new(items)
-        when Array
-          items.each { |item| self.inventory << InventoryTransferInventory.new(item) }
-        end
-      end
-
-      def inventory
-        @inventory ||= []
-      end
-
-      def to_record
-        { "#{record_namespace}:inventory" => inventory.map(&:to_record) }
-      end
     end
   end
 end

--- a/lib/netsuite/records/item_fulfillment_package_list.rb
+++ b/lib/netsuite/records/item_fulfillment_package_list.rb
@@ -1,11 +1,9 @@
 module NetSuite
   module Records
-    class ItemFulfillmentPackageList
-      include Support::Fields
-      include Support::Records
+    class ItemFulfillmentPackageList < Support::Sublist
       include Namespaces::TranSales
 
-      fields :package
+      sublist :package, ItemFulfillmentPackage
 
       def initialize(attributes = {})
         if attributes.keys != [:package] && attributes.first
@@ -32,22 +30,8 @@ module NetSuite
         initialize_from_attributes_hash(attributes)
       end
 
-      def package=(packages)
-        case packages
-        when Hash
-          self.packages << ItemFulfillmentPackage.new(packages)
-        when Array
-          packages.each { |package| self.packages << ItemFulfillmentPackage.new(package) }
-        end
-      end
+      alias :packages :package
 
-      def packages
-        @packages ||= []
-      end
-
-      def to_record
-        { "#{record_namespace}:package" => packages.map(&:to_record) }
-      end
     end
   end
 end

--- a/lib/netsuite/records/journal_entry_line_list.rb
+++ b/lib/netsuite/records/journal_entry_line_list.rb
@@ -1,31 +1,11 @@
 module NetSuite
   module Records
-    class JournalEntryLineList
-      include Support::Fields
+    class JournalEntryLineList < Support::Sublist
       include Namespaces::TranGeneral
-      
-      fields :line
 
-      def initialize(attributes = {})
-        initialize_from_attributes_hash(attributes)
-      end
+      sublist :line, JournalEntryLine
 
-      def line=(lines)
-        case lines
-        when Hash
-          self.lines << JournalEntryLine.new(lines)
-        when Array
-          lines.each { |line| self.lines << JournalEntryLine.new(line) }
-        end
-      end
-
-      def lines
-        @items ||= []
-      end
-
-      def to_record
-        { "#{record_namespace}:line" => lines.map(&:to_record) }
-      end
+      alias :lines :line
 
     end
   end

--- a/lib/netsuite/records/member_list.rb
+++ b/lib/netsuite/records/member_list.rb
@@ -1,32 +1,13 @@
 module NetSuite
   module Records
-    class MemberList
-      include Support::Fields
+    class MemberList < Support::Sublist
       include Support::Records
       include Namespaces::ListAcct
 
-      fields :replace_all, :item_member
+      fields :replace_all
 
-      def initialize(attrs = {})
-        initialize_from_attributes_hash(attrs)
-      end
+      sublist :item_member, ItemMember
 
-      def item_member=(items)
-        case items
-        when Hash
-          self.item_member << ItemMember.new(items)
-        when Array
-          items.each { |ref| self.item_member << ItemMember.new(ref) }
-        end
-      end
-
-      def item_member
-        @item_member ||= []
-      end
-
-      def to_record
-        { "#{record_namespace}:itemMember" => item_member.map(&:to_record) }
-      end
     end
   end
 end

--- a/lib/netsuite/records/record_ref_list.rb
+++ b/lib/netsuite/records/record_ref_list.rb
@@ -1,28 +1,10 @@
 module NetSuite
   module Records
-    class RecordRefList
-      include Support::Fields
+    class RecordRefList < Support::Sublist
       include Support::Records
       include Namespaces::PlatformCore
 
-      fields :record_ref
-
-      def initialize(attrs = {})
-        initialize_from_attributes_hash(attrs)
-      end
-
-      def record_ref=(items)
-        case items
-        when Hash
-          self.record_ref << RecordRef.new(items)
-        when Array
-          items.each { |ref| self.record_ref << RecordRef.new(ref) }
-        end
-      end
-
-      def record_ref
-        @record_ref ||= []
-      end
+      sublist :record_ref, RecordRef
 
       def to_record
         {

--- a/lib/netsuite/records/units_type_uom_list.rb
+++ b/lib/netsuite/records/units_type_uom_list.rb
@@ -1,31 +1,10 @@
 module NetSuite
   module Records
-    class UnitsTypeUomList
-      include Support::Fields
+    class UnitsTypeUomList < Support::Sublist
       include Namespaces::ListAcct
 
-      fields :uom
+      sublist :uom, UnitsTypeUom
 
-      def initialize(attributes = {})
-        initialize_from_attributes_hash(attributes)
-      end
-
-      def uom=(items)
-        case items
-        when Hash
-          self.uom << UnitsTypeUom.new(items)
-        when Array
-          items.each { |item| self.uom << UnitsTypeUom.new(item) }
-        end
-      end
-
-      def uom
-        @uom ||= []
-      end
-
-      def to_record
-        { "#{record_namespace}:uom" => uom.map(&:to_record) }
-      end
     end
   end
 end

--- a/lib/netsuite/records/vendor_bill_item_list.rb
+++ b/lib/netsuite/records/vendor_bill_item_list.rb
@@ -1,31 +1,11 @@
 module NetSuite
   module Records
-    class VendorBillItemList
-      include Support::Fields
+    class VendorBillItemList < Support::Sublist
       include Namespaces::TranPurch
 
-      fields :item
+      sublist :item, VendorBillItem
 
-      def initialize(attributes = {})
-        initialize_from_attributes_hash(attributes)
-      end
-
-      def item=(items)
-        case items
-        when Hash
-          self.items << VendorBillItem.new(items)
-        when Array
-          items.each { |item| self.items << VendorBillItem.new(item) }
-        end
-      end
-
-      def items
-        @items ||= []
-      end
-
-      def to_record
-        { "#{record_namespace}:item" => items.map(&:to_record) }
-      end
+      alias :items :item
 
     end
   end

--- a/lib/netsuite/records/vendor_payment_apply_list.rb
+++ b/lib/netsuite/records/vendor_payment_apply_list.rb
@@ -1,31 +1,11 @@
 module NetSuite
   module Records
-    class VendorPaymentApplyList
-      include Support::Fields
+    class VendorPaymentApplyList < Support::Sublist
       include Namespaces::TranPurch
 
-      fields :apply
+      sublist :apply, VendorPaymentApply
 
-      def initialize(attributes = {})
-        initialize_from_attributes_hash(attributes)
-      end
-
-      def apply=(applies)
-        case applies
-          when Hash
-            @applies = [VendorPaymentApply.new(applies)]
-          when Array
-            @applies = applies.map { |apply| VendorPaymentApply.new(apply) }
-        end
-      end
-
-      def applies
-        @applies ||= []
-      end
-
-      def to_record
-        { "#{record_namespace}:apply" => applies.map(&:to_record) }
-      end
+      alias :applies :apply
 
     end
   end

--- a/lib/netsuite/records/work_order_item_list.rb
+++ b/lib/netsuite/records/work_order_item_list.rb
@@ -1,31 +1,11 @@
 module NetSuite
   module Records
-    class WorkOrderItemList
-      include Support::Fields
+    class WorkOrderItemList < Support::Sublist
       include Namespaces::TranInvt
 
-      fields :item
+      sublist :item, WorkOrderItem
 
-      def initialize(attributes = {})
-        initialize_from_attributes_hash(attributes)
-      end
-
-      def item=(items)
-        case items
-        when Hash
-          self.items << WorkOrderItem.new(items)
-        when Array
-          items.each { |item| self.items << WorkOrderItem.new(item) }
-        end
-      end
-
-      def items
-        @items ||= []
-      end
-
-      def to_record
-        { "#{record_namespace}:item" => items.map(&:to_record) }
-      end
+      alias :items :item
     end
   end
 end


### PR DESCRIPTION
It seemed there was common behavior in a bunch of the list objects could be refactored to use `Support::Sublist` instead. So I gave it a go.

Happy to combine all of this into a single commit, if that's preferable!