### PR TITLE
Support pulling roles, WSDL, and account_ids using only email and password

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ gemspec
 
 gem 'simplecov', :require => false
 gem 'pry-nav'
+gem 'json', '~> 1.8.3'
+gem 'rack', '~> 1.6.4'

--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -5,6 +5,7 @@ require 'netsuite/version'
 require 'netsuite/errors'
 require 'netsuite/utilities'
 require 'netsuite/rest/utilities/roles'
+require 'netsuite/rest/utilities/request'
 require 'netsuite/core_ext/string/lower_camelcase'
 
 module NetSuite

--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -4,6 +4,7 @@ require 'savon'
 require 'netsuite/version'
 require 'netsuite/errors'
 require 'netsuite/utilities'
+require 'netsuite/rest/utilities/roles'
 require 'netsuite/core_ext/string/lower_camelcase'
 
 module NetSuite
@@ -226,8 +227,8 @@ module NetSuite
     autoload :VendorCreditApplyList,            'netsuite/records/vendor_credit_apply_list'
     autoload :VendorCreditItem,                 'netsuite/records/vendor_credit_item'
     autoload :VendorCreditItemList,             'netsuite/records/vendor_credit_item_list'
-    autoload :VendorCreditExpense,                 'netsuite/records/vendor_credit_expense'
-    autoload :VendorCreditExpenseList,             'netsuite/records/vendor_credit_expense_list'
+    autoload :VendorCreditExpense,              'netsuite/records/vendor_credit_expense'
+    autoload :VendorCreditExpenseList,          'netsuite/records/vendor_credit_expense_list'
     autoload :VendorPayment,                    'netsuite/records/vendor_payment'
     autoload :VendorPaymentApply,               'netsuite/records/vendor_payment_apply'
     autoload :VendorPaymentApplyList,           'netsuite/records/vendor_payment_apply_list'

--- a/lib/netsuite/rest/utilities/request.rb
+++ b/lib/netsuite/rest/utilities/request.rb
@@ -1,0 +1,53 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+module NetSuite
+  module Rest
+    module Utilities
+      class Request
+
+        BASE_API = "https://rest.netsuite.com/rest"
+        DEFAULT_TIMEOUT = 30
+        USE_SSL = true
+
+        class << self
+
+          def get(options)
+            email       = encode(options.fetch :email)
+            signature   = encode(options.fetch :password)
+            uri         = options.fetch(:uri)
+            response    = make_request(:get, uri, email, signature)
+            [response.code, JSON.parse(response.body)]
+          end
+
+          private
+
+          def make_request(method_name, uri, email, signature)
+            uri = URI(BASE_API + uri)
+            klass = Module.const_get "Net::HTTP::#{method_name.to_s.capitalize}"
+            method = klass.new(uri)
+            method['AUTHORIZATION'] = auth_header(email, signature)
+
+            http = Net::HTTP.new(uri.hostname, uri.port)
+            http.use_ssl      = USE_SSL
+            http.read_timeout = DEFAULT_TIMEOUT
+            http.start {|http| http.request(method)}
+          end
+
+          def auth_header(email, signature)
+            "NLAuth nlauth_email=#{email},nlauth_signature=#{signature}"
+          end
+
+          def encode(unencoded_string)
+            URI.escape(
+              unencoded_string,
+              /[#{URI::PATTERN::RESERVED}]/
+            )
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/netsuite/rest/utilities/roles.rb
+++ b/lib/netsuite/rest/utilities/roles.rb
@@ -1,0 +1,85 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
+module NetSuite
+  module Rest
+    module Utilities
+      class Roles
+
+        ROLES_API = "https://rest.netsuite.com/rest/roles"
+
+        def self.get(credentials)
+          new(credentials).get
+        end
+
+        def initialize(credentials)
+          @email     = encode_email(credentials.fetch(:email))
+          @signature = credentials.fetch(:password)
+        end
+
+        def get
+          response = make_request
+          parsed   = JSON.parse(response.body)
+          if reponse.code.to_i == 200
+            extract(parsed)
+          else
+            parsed
+          end
+        end
+
+        private
+
+        def encode_email(unencoded_email)
+          URI.escape(
+            unencoded_email,
+            Regexp.new("[^#{URI::PATTERN::UNRESERVED}]")
+          )
+        end
+
+        def make_request
+          uri = URI(ROLES_API)
+          request = Net::HTTP::Get.new(uri)
+          request['AUTHORIZATION'] = "NLAuth " +
+            "nlauth_email=#{@email},nlauth_signature=#{@signature}"
+
+          http = Net::HTTP.new(uri.hostname, uri.port)
+          http.use_ssl = true
+
+          http.start {|http| http.request(request)}
+        end
+
+        def extract(parsed)
+          # [
+          #   {
+          #    "account"=>{
+          #      "internalId"=>"TSTDRV15",
+          #      "name"=>"Honeycomb Mfg SDN (Leading)"},
+          #    "role"=>{
+          #      "internalId"=>3,
+          #      "name"=>"Administrator"},
+          #    "dataCenterURLs"=>{
+          #      "webservicesDomain"=>"https://webservices.na1.netsuite.com",
+          #      "restDomain"=>"https://rest.na1.netsuite.com",
+          #      "systemDomain"=>"https://system.na1.netsuite.com"}
+          #    },
+          #   {
+          #    "account"=>{
+          #      "internalId"=>"TSTDRV15",
+          #      "name"=>"Honeycomb Mfg SDN (Leading)"},
+          #    "role"=>{
+          #      "internalId"=>1074,
+          #      "name"=>"Custom Role"},
+          #   ....
+
+          {
+            accounts: parsed.map {|hash| hash["account"]["internalId"] }.uniq,
+            roles:    parsed.map {|hash| hash["role"]["internalId"] }.uniq,
+            wsdls:    parsed.map {|hash| hash["dataCenterURLs"]["webservicesDomain"] }.uniq,
+          }
+        end
+
+      end
+    end
+  end
+end

--- a/lib/netsuite/rest/utilities/roles.rb
+++ b/lib/netsuite/rest/utilities/roles.rb
@@ -1,81 +1,44 @@
-require 'net/http'
-require 'uri'
-require 'json'
-
 module NetSuite
   module Rest
     module Utilities
       class Roles
 
-        ROLES_API = "https://rest.netsuite.com/rest/roles"
+        class << self
 
-        def self.get(*args)
-          new(*args).get
+          def get(email, password)
+            code, body = Request.get(
+              email: email,
+              password: password,
+              uri: '/roles'
+            )
+            code == "200" ? format_response(body) : body
+          end
+
+          private
+
+          def format_response(parsed)
+            # [
+            #   {
+            #    "account"=>{
+            #      "internalId"=>"TSTDRV15",
+            #      "name"=>"Honeycomb Mfg SDN (Leading)"},
+            #    "role"=>{
+            #      "internalId"=>3,
+            #      "name"=>"Administrator"},
+            #    "dataCenterURLs"=>{
+            #      "webservicesDomain"=>"https://webservices.na1.netsuite.com",
+            #      "restDomain"=>"https://rest.na1.netsuite.com",
+            #      "systemDomain"=>"https://system.na1.netsuite.com"}
+            #    },
+            #   ....
+            {
+              accounts: parsed.map {|hash| hash["account"]["internalId"] }.uniq,
+              roles:    parsed.map {|hash| hash["role"]["internalId"] }.uniq,
+              wsdls:    parsed.map {|hash| hash["dataCenterURLs"]["webservicesDomain"] }.uniq,
+            }
+          end
+
         end
-
-        def initialize(credentials)
-          @email     = encode(credentials.fetch :email)
-          @signature = encode(credentials.fetch :password)
-        end
-
-        def get
-          response = make_request
-          parsed   = JSON.parse(response.body)
-          response.code == "200" ? extract(parsed) : parsed
-        end
-
-        private
-
-        def encode(unencoded_string)
-          URI.escape(
-            unencoded_string,
-            /[#{URI::PATTERN::RESERVED}]/
-          )
-        end
-
-        def make_request
-          uri = URI(ROLES_API)
-          get = Net::HTTP::Get.new(uri)
-          get['AUTHORIZATION'] = "NLAuth " +
-            "nlauth_email=#{@email}," +
-            "nlauth_signature=#{@signature}"
-
-          http = Net::HTTP.new(uri.hostname, uri.port)
-          http.use_ssl = true
-          http.read_timeout = 30
-          http.start {|http| http.request(get)}
-        end
-
-        def extract(parsed)
-          # [
-          #   {
-          #    "account"=>{
-          #      "internalId"=>"TSTDRV15",
-          #      "name"=>"Honeycomb Mfg SDN (Leading)"},
-          #    "role"=>{
-          #      "internalId"=>3,
-          #      "name"=>"Administrator"},
-          #    "dataCenterURLs"=>{
-          #      "webservicesDomain"=>"https://webservices.na1.netsuite.com",
-          #      "restDomain"=>"https://rest.na1.netsuite.com",
-          #      "systemDomain"=>"https://system.na1.netsuite.com"}
-          #    },
-          #   {
-          #    "account"=>{
-          #      "internalId"=>"TSTDRV15",
-          #      "name"=>"Honeycomb Mfg SDN (Leading)"},
-          #    "role"=>{
-          #      "internalId"=>1074,
-          #      "name"=>"Custom Role"},
-          #   ....
-
-          {
-            accounts: parsed.map {|hash| hash["account"]["internalId"] }.uniq,
-            roles:    parsed.map {|hash| hash["role"]["internalId"] }.uniq,
-            wsdls:    parsed.map {|hash| hash["dataCenterURLs"]["webservicesDomain"] }.uniq,
-          }
-        end
-
       end
     end
   end

--- a/spec/netsuite/utilities/request_spec.rb
+++ b/spec/netsuite/utilities/request_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe NetSuite::Rest::Utilities::Request do
+  subject { described_class }
+
+  describe '#get' do
+    it { is_expected.to respond_to :get }
+    let(:default_args) do
+      { email: 'jim@godaddy.com', password: 'secret', uri: '/sandwich'}
+    end
+
+    [:email, :password, :uri].each do |key|
+      it "throws an error if no #{key} key is given" do
+        expect{
+          subject.get(default_args.delete_if{|x| x == key})
+        }.to raise_error(KeyError)
+      end
+    end
+
+    it 'returns an array with the response code and parsed body' do
+      allow(subject).to receive(:make_request).and_return(
+        double(:response, code: "200", body: [{great: :body}].to_json)
+      )
+      expect( subject.get(default_args) ).to eq ["200", [{"great" => "body"}]]
+    end
+  end
+
+
+end

--- a/spec/netsuite/utilities/roles_spec.rb
+++ b/spec/netsuite/utilities/roles_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+describe NetSuite::Rest::Utilities::Roles do
+  subject { described_class }
+
+  describe '#get' do
+    it { is_expected.to respond_to :get }
+
+    it 'invokes the request module' do
+      expect( NetSuite::Rest::Utilities::Request ).to receive(:get)
+      subject.get('jimbob@netzero.com', 'pickles')
+    end
+
+    it 'formats the API response if successful' do
+      allow( NetSuite::Rest::Utilities::Request ).to receive(:get).and_return(
+        ["200", {parsed: :response}]
+      )
+      expect( subject ).to receive(:format_response).with({parsed: :response}).and_return nil
+      subject.get('jimbob@netzero.com', 'pickles')
+    end
+
+    it 'returns the full error message if unsuccessful' do
+      allow( NetSuite::Rest::Utilities::Request ).to receive(:get).and_return(
+        ["500", {oh: :no!}]
+      )
+      expect( subject ).to_not receive(:format_reponse)
+      expect( subject.get('jimbob@netzero.com', 'pickles') ).to eq({oh: :no!})
+    end
+  end
+
+  describe '#format_response' do
+    let(:parsed) do
+      [
+        {
+          "account"=>{
+            "internalId"=>"TSTDRV15",
+            "name"=>"Honeycomb Mfg SDN (Leading)"},
+          "role"=>{
+              "internalId"=>3,
+              "name"=>"Administrator"},
+              "dataCenterURLs"=>{
+                "webservicesDomain"=>"https://webservices.na1.netsuite.com",
+                "restDomain"=>"https://rest.na1.netsuite.com",
+                "systemDomain"=>"https://system.na1.netsuite.com"}
+        },
+        {
+          "account"=>{
+            "internalId"=>"TSTDRV15",
+            "name"=>"Honeycomb Mfg SDN (Leading)"},
+          "role"=>{
+              "internalId"=>1,
+              "name"=>"Accountant"},
+              "dataCenterURLs"=>{
+                "webservicesDomain"=>"https://webservices.na1.netsuite.com",
+                "restDomain"=>"https://rest.na1.netsuite.com",
+                "systemDomain"=>"https://system.na1.netsuite.com"}
+        },
+        {
+          "account"=>{
+            "internalId"=>"TSTDRV14",
+            "name"=>"Honeycomb Mfg SDN (Leading)"},
+          "role"=>{
+              "internalId"=>1,
+              "name"=>"Accountant"},
+              "dataCenterURLs"=>{
+                "webservicesDomain"=>"https://webservices.na1.netsuite.com",
+                "restDomain"=>"https://rest.na1.netsuite.com",
+                "systemDomain"=>"https://system.na1.netsuite.com"}
+        },
+      ]
+    end
+
+    it 'pulls out the account_ids' do
+      expect(
+        subject.send(:format_response, parsed).fetch(:accounts)
+      ).to eq ["TSTDRV15","TSTDRV14"]
+    end
+
+    it 'pulls out the role_ids' do
+      expect(
+        subject.send(:format_response, parsed).fetch(:roles)
+      ).to eq [3, 1]
+    end
+
+    it 'pulls out the wsdls' do
+      expect(
+        subject.send(:format_response, parsed).fetch(:wsdls)
+      ).to eq ["https://webservices.na1.netsuite.com"]
+    end
+
+    it 'handles an empty response body' do
+      expect{
+        subject.send(:format_response, [])
+      }.to_not raise_error
+    end
+
+  end
+end


### PR DESCRIPTION
@iloveitaly This is a work in progress/proof of concept. Just throwing it up here to get feedback on the approach, architecture, etc!

Usage:

```ruby
NetSuite::Rest::Utilities::Roles.get(
  email: NetSuite::Configuration.email,
  password: NetSuite::Configuration.password
)
=> {
 :accounts=>["TSTDRV15"],
 :roles=>[3, 1074, 1, 46],
 :wsdls=>["https://webservices.na1.netsuite.com"]
}
```

Still needs tests, and error handling.