### PR TITLE
Fix bug in #get_all when the user lacks permission

### DIFF
--- a/lib/netsuite/actions/get_all.rb
+++ b/lib/netsuite/actions/get_all.rb
@@ -38,7 +38,11 @@ module NetSuite
       end
 
       def response_body
-        @response_body ||= array_wrap(response_hash[:record_list][:record])
+        @response_body ||= if response_hash[:record_list]
+          array_wrap(response_hash[:record_list][:record])
+        elsif response_hash[:status][:status_detail][:@type] == "ERROR"
+          NetSuite::Error.new(response_hash[:status][:status_detail])
+        end
       end
 
       def response_hash
@@ -57,7 +61,7 @@ module NetSuite
             if response.success?
               response.body.map { |attr| new(attr) }
             else
-              raise RecordNotFound, "#{self} with OPTIONS=#{options.inspect} could not be found"
+              raise RecordNotFound, response.body.message
             end
           end
         end


### PR DESCRIPTION
Try `NetSuite::Records::Currency.get_all` with a role that lacks
Currency List permissions. The response you get is:

```XML
  <platformCore:status isSuccess="false">
    <platformCore:statusDetail type="ERROR">
      <platformCore:code>INSUFFICIENT_PERMISSION</platformCore:code>
      <platformCore:message>Permission Violation: You need  the
        'Lists -&gt; Currency' permission to access this page. Please
        contact your account administrator.</platformCore:message>
    </platformCore:statusDetail>
  </platformCore:status>
```

Because of this[ `response_hash[:record_list]`](https://github.com/NetSweet/netsuite/blob/eb13f4b5c8d8eba8e0a7f4906eaebda455d641a3/lib/netsuite/actions/get_all.rb#L41) is `nil`, and so `response_hash[:record_list][:record]` raises:

```
  NoMethodError: undefined method `[]' for nil:NilClass
```

This prevents that from happening