### PR TITLE
Allow usage of `type` to instantiate a custom field from a hash

### DIFF
--- a/lib/netsuite/records/custom_field_list.rb
+++ b/lib/netsuite/records/custom_field_list.rb
@@ -97,7 +97,7 @@ module NetSuite
 
         def extract_custom_field(custom_field_data)
           # TODO this seems brittle, but might sufficient, watch out for this if something breaks
-          if custom_field_data[:"@xsi:type"] == "platformCore:SelectCustomFieldRef"
+          if (custom_field_data[:"@xsi:type"] || custom_field_data[:type]) == "platformCore:SelectCustomFieldRef"
             custom_field_data[:value] = CustomRecordRef.new(custom_field_data.delete(:value))
           end
 

--- a/spec/netsuite/records/custom_field_list_spec.rb
+++ b/spec/netsuite/records/custom_field_list_spec.rb
@@ -102,7 +102,7 @@ describe NetSuite::Records::CustomFieldList do
 
     it 'can represent itself as a SOAP record' do
       record = {
-      "platformCore:customField" => [
+        "platformCore:customField" => [
           {
             'platformCore:value' => 'false',
             "@internalId" => "custentity_registeredonline",
@@ -123,6 +123,47 @@ describe NetSuite::Records::CustomFieldList do
 
       expect(list.to_record).to eql(record)
       expect(list.to_record.length).to eq(1)
+    end
+
+    context "when custom field list is initialised from a hash" do
+      let(:attributes) do
+        {
+          custom_field: [
+            {
+              script_id: "custentity_registeredonline",
+              type: "platformCore:SelectCustomFieldRef",
+              value: { internal_id: 200, type_id: 1 },
+            },
+            {
+              script_id: "custbody_salesclassification",
+              type: "platformCore:StringCustomFieldRef",
+              value: "foobar"
+            }
+          ]
+        }
+      end
+
+      it "can represent itself as a SOAP record" do
+        list = NetSuite::Records::CustomFieldList.new(attributes)
+
+        record = {
+          "platformCore:customField" => [
+            {
+              "@scriptId" => "custentity_registeredonline",
+              "@xsi:type" => "platformCore:SelectCustomFieldRef",
+              "platformCore:value" => {:@internalId => 200, :@typeId => "1"},
+            },
+            {
+              "@scriptId" => "custbody_salesclassification",
+              "@xsi:type" => "platformCore:StringCustomFieldRef",
+              "platformCore:value" => "foobar",
+            },
+          ]
+        }
+
+        expect(list.to_record).to eql(record)
+        expect(list.to_record.length).to eq(1)
+      end
     end
 
     # https://github.com/NetSweet/netsuite/issues/182


### PR DESCRIPTION
Hi,

I've been working on a netsuite integration and this gem fit like a glove to me. So many thanks for all work that has been put into it.

To make things simpler, I first build a hash with the appropriate keys and sub-hashes, and only then, I initialise a netsuite record to call `#add`.

I realised that a CustomField already takes [`type` or `@xsi:type`](https://github.com/NetSweet/netsuite/blob/master/lib/netsuite/records/custom_field.rb#L13) to initialise.

Since I use CustomFields initialised from within a CustomFieldList, I'd rather use type so my code looks like more idiomatic as opposed to `@xsi:type`. 

I've added a test to make sure the output is as expected.

Let me know if any changes are required.

Cheers
Ricardo