### PR TITLE
Add `NetSuite::Configuration#logger=`

### DIFF
--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -286,11 +286,15 @@ module NetSuite
     end
 
     def logger(value = nil)
-      attributes[:logger] = if value.nil?
-        ::Logger.new((log && !log.empty?) ? log : $stdout)
+      if value.nil?
+        attributes[:logger] ||= ::Logger.new((log && !log.empty?) ? log : $stdout)
       else
-        value
+        attributes[:logger] = value
       end
+    end
+
+    def logger=(value)
+      attributes[:logger] = value
     end
 
     def silent(value=nil)

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -261,4 +261,16 @@ describe NetSuite::Configuration do
     expect(config.wsdl_domain).to eq('webservices.sandbox.netsuite.com')
   end
 
+  describe '#logger=' do
+    let(:logger) { Logger.new(nil) }
+
+    before do
+      config.logger = logger
+    end
+
+    it 'sets logger' do
+      expect(config.logger).to eql(logger)
+    end
+  end
+
 end


### PR DESCRIPTION
Allows configuration of a logger. Useful for using a centralized logger or tagged logging or a logger with multiple backends.