### PR TITLE
[WIP] Attach primary contact

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -37,6 +37,7 @@ module NetSuite
   module Support
     autoload :Actions,    'netsuite/support/actions'
     autoload :Attributes, 'netsuite/support/attributes'
+    autoload :Attachment, 'netsuite/support/attachment'
     autoload :Fields,     'netsuite/support/fields'
     autoload :Sublist,    'netsuite/support/sublist'
     autoload :RecordRefs, 'netsuite/support/record_refs'
@@ -48,6 +49,7 @@ module NetSuite
 
   module Actions
     autoload :Add,              'netsuite/actions/add'
+    autoload :Attach,           'netsuite/actions/attach'
     autoload :Delete,           'netsuite/actions/delete'
     autoload :DeleteList,       'netsuite/actions/delete_list'
     autoload :Get,              'netsuite/actions/get'
@@ -67,6 +69,7 @@ module NetSuite
     autoload :Account,                          'netsuite/records/account'
     autoload :AccountingPeriod,                 'netsuite/records/accounting_period'
     autoload :Address,                          'netsuite/records/address'
+    autoload :AttachContactReference,           'netsuite/records/attach_contact_reference'
     autoload :BaseRefList,                      'netsuite/records/base_ref_list'
     autoload :BillAddress,                      'netsuite/records/bill_address'
     autoload :BillingSchedule,                  'netsuite/records/billing_schedule'

--- a/lib/netsuite/actions/attach.rb
+++ b/lib/netsuite/actions/attach.rb
@@ -1,0 +1,82 @@
+module NetSuite
+  module Actions
+    class Attach
+      include Support::Requests
+
+      attr_reader :response_hash
+
+      def initialize(object, object_to_attach)
+        @object = object
+        @object_to_attach = object_to_attach
+      end
+
+      private
+
+      def request(credentials = {})
+        NetSuite::Configuration.connection({}, credentials).call(:attach, :message => request_body)
+      end
+
+      # <soap:Body>
+      #   <platformMsgs:attach>
+      #      <platformMsgs:attachReference xsi:type="s0:AttachContactReference">
+      #         <s0:attachTo xsi:type="s0:RecordRef" internalId="9044" type="customer" />
+      #         <s0:contact internalId="9045" />
+      #         <s0:contactRole internalId="-10" />
+      #      </platformMsgs:attachReference>
+      #   </platformMsgs:attach>
+      # </soap:Body>
+
+      def request_body
+        base_xml = {
+          'platformMsgs:attachReference' => {
+            :content! => @object.to_record,
+            '@xsi:type' => @object.record_type
+          }
+        }
+
+        base_xml.tap do |body|
+          if @object_to_attach.respond_to?(:to_attachment)
+            @object_to_attach.to_attachment.each do |key, value|
+              body["platformMsgs:attachReference"][:content!][key] = {}
+              body["platformMsgs:attachReference"][:content!][:attributes!][key] = value
+            end
+          end
+        end
+      end
+
+      def success?
+        @success ||= response_hash[:status][:@is_success] == 'true'
+      end
+
+      def response_body
+        @response_body ||= response_hash[:base_ref]
+      end
+
+      def response_errors
+        if response_hash[:status] && response_hash[:status][:status_detail]
+          @response_errors ||= errors
+        end
+      end
+
+      def response_hash
+        @response_hash ||= @response.to_hash[:attach_response][:write_response]
+      end
+
+      def errors
+        error_obj = response_hash[:status][:status_detail]
+        error_obj = [error_obj] if error_obj.class == Hash
+        error_obj.map do |error|
+          NetSuite::Error.new(error)
+        end
+      end
+
+      module Support
+        def attach(object_to_attach, credentials = {})
+          response = NetSuite::Actions::Attach.call([self, object_to_attach], credentials)
+          @errors = response.errors
+          response.success?
+        end
+      end
+    end
+  end
+end

--- a/lib/netsuite/records/attach_contact_reference.rb
+++ b/lib/netsuite/records/attach_contact_reference.rb
@@ -1,0 +1,20 @@
+# http://www.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2016_2/schema/other/attachcontactreference.html?mode=package
+
+module NetSuite
+  module Records
+    class AttachContactReference
+      include Support::Fields
+      include Support::RecordRefs
+      include Support::Records
+      include Support::Actions
+
+      actions :attach
+
+      record_refs :contact, :contact_role
+
+      def initialize(attributes = {})
+        initialize_from_attributes_hash(attributes)
+      end
+    end
+  end
+end

--- a/lib/netsuite/records/customer.rb
+++ b/lib/netsuite/records/customer.rb
@@ -5,6 +5,7 @@ module NetSuite
       include Support::RecordRefs
       include Support::Records
       include Support::Actions
+      include Support::Attachment
       include Namespaces::ListRel
 
       actions :get, :get_list, :add, :update, :upsert, :upsert_list, :delete, :delete_list, :search
@@ -32,7 +33,7 @@ module NetSuite
       field :contact_roles_list, ContactAccessRolesList
       field :currency_list, CustomerCurrencyList
       field :partners_list, CustomerPartnersList
-      
+
       # TODO subscriptions_list
 
       read_only_fields :balance, :consol_balance, :deposit_balance, :consol_deposit_balance, :overdue_balance,

--- a/lib/netsuite/support/actions.rb
+++ b/lib/netsuite/support/actions.rb
@@ -42,6 +42,8 @@ module NetSuite
             self.send(:include, NetSuite::Actions::Update::Support)
           when :initialize
             self.send(:include, NetSuite::Actions::Initialize::Support)
+          when :attach
+            self.send(:include, NetSuite::Actions::Attach::Support)
           else
             raise "Unknown action: #{name.inspect}"
           end

--- a/lib/netsuite/support/attachment.rb
+++ b/lib/netsuite/support/attachment.rb
@@ -1,0 +1,22 @@
+module NetSuite
+  module Support
+    module Attachment
+      include Attributes
+      include Namespaces::PlatformCore
+
+      def to_attachment
+        {
+          "platformCore:attachTo" => {
+            "xsi:type" => "platformCore:RecordRef",
+            "internalId" => internal_id,
+            "type" => soap_type,
+          }
+        }
+      end
+
+      def soap_type
+        self.class.to_s.split('::').last.lower_camelcase
+      end
+    end
+  end
+end

--- a/spec/netsuite/records/customer_spec.rb
+++ b/spec/netsuite/records/customer_spec.rb
@@ -171,6 +171,20 @@ describe NetSuite::Records::Customer do
     end
   end
 
+  describe "#to_attachment" do
+    let(:customer) { NetSuite::Records::Customer.new(:internal_id => 123) }
+
+    it 'returns a hash of attributes that can be used in a SOAP attach request' do
+      expect(customer.to_attachment).to eql({
+        "platformCore:attachTo" => {
+          "xsi:type" => "platformCore:RecordRef",
+          "internalId" => 123,
+          "type" => "customer"
+        }
+      })
+    end
+  end
+
   describe '#record_type' do
     it 'returns a string type for the record to be used in a SOAP request' do
       expect(customer.record_type).to eql('listRel:Customer')


### PR DESCRIPTION
Hi @iloveitaly,

I'm currently opening this pull request as a WIP to get your opinion on the design of https://github.com/NetSweet/netsuite/issues/299 (disclaimer: I work with @jamesottaway)

Based on http://www.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2016_2/schema/other/attachcontactreference.html?mode=package, I assume AttachContactReference is a record where the attributes include contact and contact role.

The customer is the object to be attached to the tuple contact + role. 

Given the above, I came up with the following idea:

```ruby
customer = NetSuite::Records::Customer.new(internal_id: 1)
NetSuite::Records::AttachContactReference.new(contact: { internal_id: 1 }, contact_role: { internal_id: -10 }).attach(customer)
```

Sorry for the lack of tests at this point. I spat out the ideas to get my head around and would appreciate an initial feedback before I clean it up and put some tests.

Thanks
Ricardo