### PR TITLE
Add `#update` action to `NetSuite::Records::NonInventorySaleItem#update`

### DIFF
--- a/lib/netsuite/records/non_inventory_sale_item.rb
+++ b/lib/netsuite/records/non_inventory_sale_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :delete, :search, :upsert
+      actions :get, :get_list, :add, :delete, :search, :update, :upsert
 
       fields :available_to_partners, :cost_estimate, :cost_estimate_type, :cost_estimate_units, :country_of_manufacture,
         :created_date, :display_name, :dont_show_price, :enforce_min_qty_internally, :exclude_from_sitemap,

--- a/spec/netsuite/records/non_inventory_sale_item_spec.rb
+++ b/spec/netsuite/records/non_inventory_sale_item_spec.rb
@@ -91,6 +91,32 @@ describe NetSuite::Records::NonInventorySaleItem do
     end
   end
 
+  describe '#update' do
+    context 'when the response is successful' do
+      let(:response) { NetSuite::Response.new(:success => true, :body => { :internal_id => '1' }) }
+
+      it 'returns true' do
+        expect(NetSuite::Actions::Update).to receive(:call).
+            with([item.class, {external_id: 'foo'}], {}).
+            and_return(response)
+        item.external_id = 'foo'
+        expect(item.update).to be_truthy
+      end
+    end
+
+    context 'when the response is unsuccessful' do
+      let(:response) { NetSuite::Response.new(:success => false, :body => {}) }
+
+      it 'returns false' do
+        expect(NetSuite::Actions::Update).to receive(:call).
+            with([item.class, {external_id: 'foo'}], {}).
+            and_return(response)
+        item.external_id = 'foo'
+        expect(item.update).to be_falsey
+      end
+    end
+  end
+
   describe '#delete' do
     context 'when the response is successful' do
       let(:response) { NetSuite::Response.new(:success => true, :body => { :internal_id => '1' }) }


### PR DESCRIPTION
In the event the external ID needs to be updated for a non-inventory sale item, an update action must be available.

We had this happen in our case and attempted to just use `#upsert`. However, since upserting depends on matching external IDs, we got back error responses.