### PR TITLE
Cache missing record requests

### DIFF
--- a/lib/netsuite/utilities.rb
+++ b/lib/netsuite/utilities.rb
@@ -92,8 +92,8 @@ module NetSuite
         @netsuite_get_record_cache ||= {}
         @netsuite_get_record_cache[record_klass.to_s] ||= {}
 
-        if cached_record = @netsuite_get_record_cache[record_klass.to_s][id.to_i]
-          return cached_record
+        if @netsuite_get_record_cache[record_klass.to_s].has_key?(id.to_i)
+          return @netsuite_get_record_cache[record_klass.to_s][id.to_i]
         end
       end
 
@@ -113,6 +113,10 @@ module NetSuite
         return ns_record
       rescue ::NetSuite::RecordNotFound
         # log.warn("record not found", ns_record_type: record_klass.name, ns_record_id: id)
+        if opts[:cache]
+          @netsuite_get_record_cache[record_klass.to_s][id.to_i] = nil
+        end
+
         return nil
       end
     end

--- a/spec/netsuite/utilities_spec.rb
+++ b/spec/netsuite/utilities_spec.rb
@@ -2,17 +2,36 @@ require 'spec_helper'
 
 describe NetSuite::Utilities do
   describe '#get_record' do
-    it 'does not hit the netsuite API when caching is enabled' do
-      ns_account_id = 123
-      allow(NetSuite::Records::Account).to receive(:get).with(ns_account_id).once.and_return(
-        NetSuite::Records::Account.new(internal_id: ns_account_id)
-      )
+    context 'caching' do
+      it 'does not hit the netsuite API' do
+        ns_account_id = 123
+        allow(NetSuite::Records::Account).to receive(:get).with(ns_account_id).once.and_return(
+          NetSuite::Records::Account.new(internal_id: ns_account_id)
+        )
 
-      ns_account = NetSuite::Utilities.get_record(NetSuite::Records::Account, ns_account_id, cache: true)
-      expect(ns_account.internal_id).to eq(ns_account_id)
+        ns_account = NetSuite::Utilities.get_record(NetSuite::Records::Account, ns_account_id, cache: true)
+        expect(ns_account.internal_id).to eq(ns_account_id)
 
-      ns_account = NetSuite::Utilities.get_record(NetSuite::Records::Account, ns_account_id, cache: true)
-      expect(ns_account.internal_id).to eq(ns_account_id)
+        ns_account = NetSuite::Utilities.get_record(NetSuite::Records::Account, ns_account_id, cache: true)
+        expect(ns_account.internal_id).to eq(ns_account_id)
+      end
+
+      it 'works on missing records' do
+        ns_account_id = 123
+        allow(NetSuite::Records::Account).to receive(:get).with(ns_account_id) do
+          raise NetSuite::RecordNotFound
+        end
+
+        20.times do
+          expect(
+            NetSuite::Utilities.get_record(
+              NetSuite::Records::Account, ns_account_id, cache: true
+            )
+          ).to eq nil
+        end
+
+        expect(NetSuite::Records::Account).to have_received(:get).exactly(1).times
+      end
     end
 
     it 'pulls a record by internal id' do


### PR DESCRIPTION
Currently `NetSuite::Utilities#get_record` doesn't cache the results of requests for non-existent records, e.g. for record X when there is no record with id X. But it probably should. These requests will return the same response even if made multiple times.

Check out the spec to reproduce the issue this fixes.

The tests actually pass. CI is failing b/c of a caching issue with Ruby/nokogiri:

![image](https://cloud.githubusercontent.com/assets/7997618/21568389/18deefbc-ce82-11e6-9602-4cfec1b41312.png)
