### PR TITLE
WIP Thread safe per-request configuration

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -253,6 +253,7 @@ module NetSuite
   end
 
   def self.configure(&block)
-    NetSuite::Configuration.instance_eval(&block)
+    Thread.current[:netsuite_configuration] ||= NetSuite::Configuration.new
+    Thread.current[:netsuite_configuration].instance_eval(&block)
   end
 end

--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -255,24 +255,4 @@ module NetSuite
   def self.configure(&block)
     NetSuite::Configuration.instance_eval(&block)
   end
-
-  def self.configure_from_env(&block)
-    NetSuite.configure do
-      reset!
-
-      email         ENV['NETSUITE_EMAIL']     unless ENV['NETSUITE_EMAIL'].nil?
-      password      ENV['NETSUITE_PASSWORD']  unless ENV['NETSUITE_PASSWORD'].nil?
-      account       ENV['NETSUITE_ACCOUNT']   unless ENV['NETSUITE_ACCOUNT'].nil?
-      role          ENV['NETSUITE_ROLE']      unless ENV['NETSUITE_ROLE'].nil?
-      api_version   ENV['NETSUITE_API']       unless ENV['NETSUITE_API'].nil?
-      sandbox       (ENV['NETSUITE_PRODUCTION'].nil? || ENV['NETSUITE_PRODUCTION'] != 'true')
-      wsdl          ENV['NETSUITE_WSDL']      unless ENV['NETSUITE_WSDL'].nil?
-      silent        (!ENV['NETSUITE_SILENT'].nil? && ENV['NETSUITE_SILENT'] == 'true')
-
-      read_timeout  100_000
-    end
-
-    self.configure(&block) if block
-  end
-
 end

--- a/lib/netsuite/actions/add.rb
+++ b/lib/netsuite/actions/add.rb
@@ -12,8 +12,9 @@ module NetSuite
 
       private
 
-      def request(credentials={})
-        NetSuite::Configuration.connection({}, credentials).call(:add, :message => request_body)
+      def request(credentials = nil)
+        configuration ||= NetSuite::Configuration
+        configuration.connection.call(:add, message: request_body)
       end
 
       # <soap:Body>

--- a/lib/netsuite/actions/delete_list.rb
+++ b/lib/netsuite/actions/delete_list.rb
@@ -10,13 +10,9 @@ module NetSuite
 
       private
 
-      def request(credentials={})
-        NetSuite::Configuration.connection(
-          {namespaces: {
-            'xmlns:platformMsgs' => "urn:messages_#{NetSuite::Configuration.api_version}.platform.webservices.netsuite.com",
-            'xmlns:platformCore' => "urn:core_#{NetSuite::Configuration.api_version}.platform.webservices.netsuite.com"
-          }}, credentials
-        ).call :delete_list, message: request_body
+      def request(configuration = nil)
+        configuration ||= NetSuite::Configuration
+        configuration.connection.call(:delete_list, message: request_body)
       end
 
       # <soap:Body>

--- a/lib/netsuite/actions/get.rb
+++ b/lib/netsuite/actions/get.rb
@@ -11,15 +11,12 @@ module NetSuite
 
       private
 
-      def request(credentials={})
-        NetSuite::Configuration.connection(
-          {namespaces: {
-            'xmlns:platformMsgs' => "urn:messages_#{NetSuite::Configuration.api_version}.platform.webservices.netsuite.com",
-            'xmlns:platformCore' => "urn:core_#{NetSuite::Configuration.api_version}.platform.webservices.netsuite.com"
-          }}, credentials
-        ).call :get, message: request_body
+      def request(credentials = nil)
+        credentials ||= NetSuite::Configuration
+        credentials.connection.call(:get, message: request_body)
       end
 
+      # TODO DRY up this pattern
       def soap_type
         @klass.to_s.split('::').last.lower_camelcase
       end

--- a/lib/netsuite/actions/get_all.rb
+++ b/lib/netsuite/actions/get_all.rb
@@ -5,15 +5,15 @@ module NetSuite
       include Support::Requests
 
       def initialize(klass)
-        @klass   = klass
+        @klass = klass
       end
 
       private
 
-      def request(credentials={})
-        NetSuite::Configuration.connection(
-          { element_form_default: :unqualified }, credentials
-        ).call(:get_all, message: request_body)
+      def request(credentials = nil)
+        # TODO not sure why `element_form_default` is here
+        configuration ||= NetSuite::Configuration
+        configuration.connection(element_form_default: :unqualified).call(:get_all, message: request_body)
       end
 
       # <soap:Body>
@@ -56,7 +56,7 @@ module NetSuite
         end
 
         module ClassMethods
-          def get_all(credentials = {})
+          def get_all(credentials = nil)
             response = NetSuite::Actions::GetAll.call([self], credentials)
 
             # TODO expose errors to the user

--- a/lib/netsuite/actions/get_deleted.rb
+++ b/lib/netsuite/actions/get_deleted.rb
@@ -10,13 +10,9 @@ module NetSuite
 
       private
 
-      def request(credentials={})
-        NetSuite::Configuration.connection(
-          {namespaces: {
-            'xmlns:platformMsgs' => "urn:messages_#{NetSuite::Configuration.api_version}.platform.webservices.netsuite.com",
-            'xmlns:platformCore' => "urn:core_#{NetSuite::Configuration.api_version}.platform.webservices.netsuite.com"
-          }}, credentials
-        ).call :get_deleted, message: request_body
+      def request(configuration = nil)
+        configuration ||= NetSuite::Configuration
+        configuration.connection.call(:get_deleted, message: request_body)
       end
 
       def soap_type
@@ -78,8 +74,8 @@ module NetSuite
         end
 
         module ClassMethods
-          def get_deleted(options = { }, credentials={})
-            NetSuite::Actions::GetDeleted.call([self, options], credentials)
+          def get_deleted(options = {}, configuration = nil)
+            NetSuite::Actions::GetDeleted.call([self, options], configuration)
           end
         end
       end

--- a/lib/netsuite/actions/get_list.rb
+++ b/lib/netsuite/actions/get_list.rb
@@ -11,8 +11,9 @@ module NetSuite
 
       private
 
-      def request(credentials={})
-        NetSuite::Configuration.connection({}, credentials).call(:get_list, :message => request_body)
+      def request(configuration = nil)
+        configuration ||= NetSuite::Configuration
+        configuration.connection.call(:get_list, message: request_body)
       end
 
       def request_body
@@ -65,8 +66,8 @@ module NetSuite
       end
 
       def success?
-        # each returned record has its own status; 
-        if @options[:allow_incomplete] 
+        # each returned record has its own status;
+        if @options[:allow_incomplete]
           @success ||= !response_body.detect { |r| r[:status][:@is_success] == 'true' }.nil?
         else
           @success ||= response_body.detect { |r| r[:status][:@is_success] != 'true' }.nil?

--- a/lib/netsuite/actions/initialize.rb
+++ b/lib/netsuite/actions/initialize.rb
@@ -9,14 +9,9 @@ module NetSuite
         @object = object
       end
 
-      def request(credentials={})
-        NetSuite::Configuration.connection(
-          {namespaces: {
-            'xmlns:platformMsgs'    => "urn:messages_#{NetSuite::Configuration.api_version}.platform.webservices.netsuite.com",
-            'xmlns:platformCore'    => "urn:core_#{NetSuite::Configuration.api_version}.platform.webservices.netsuite.com",
-            'xmlns:platformCoreTyp' => "urn:types.core_#{NetSuite::Configuration.api_version}.platform.webservices.netsuite.com",
-          }}, credentials
-        ).call :initialize, :message => request_body
+      def request(configuration = nil)
+        configuration ||= NetSuite::Configuration
+        configuration.connection.call(:initialize, message: request_body)
       end
 
       # <platformMsgs:initializeRecord>
@@ -65,7 +60,7 @@ module NetSuite
 
         module ClassMethods
 
-          def initialize(object, credentials={})
+          def initialize(object, credentials = nil)
             response = NetSuite::Actions::Initialize.call([self, object], credentials)
             if response.success?
               new(response.body)

--- a/lib/netsuite/actions/update.rb
+++ b/lib/netsuite/actions/update.rb
@@ -11,8 +11,9 @@ module NetSuite
         @attributes = attributes
       end
 
-      def request(credentials={})
-        NetSuite::Configuration.connection({}, credentials).call :update, :message => request_body
+      def request(configuration = nil)
+        configuration ||= NetSuite::Configuration
+        configuration.connection.call(:update, message: request_body)
       end
 
       # <platformMsgs:update>
@@ -70,10 +71,10 @@ module NetSuite
       end
 
       module Support
-        def update(options = {}, credentials={})
+        def update(options = {}, configuration = nil)
           options.merge!(:internal_id => internal_id) if respond_to?(:internal_id) && internal_id
           options.merge!(:external_id => external_id) if respond_to?(:external_id) && external_id
-          response = NetSuite::Actions::Update.call([self.class, options], credentials)
+          response = NetSuite::Actions::Update.call([self.class, options], configuration)
           @errors = response.errors
           response.success?
         end

--- a/lib/netsuite/actions/upsert.rb
+++ b/lib/netsuite/actions/upsert.rb
@@ -12,8 +12,9 @@ module NetSuite
 
       private
 
-      def request(credentials={})
-        NetSuite::Configuration.connection({}, credentials).call :upsert, :message => request_body
+      def request(configuration = nil)
+        configuration ||= NetSuite::Configuration
+        configuration.connection.call(:upsert, message: request_body)
       end
 
       # <soap:Body>
@@ -67,7 +68,7 @@ module NetSuite
       end
 
       module Support
-        def upsert(credentials={})
+        def upsert(credentials = nil)
           response = NetSuite::Actions::Upsert.call([self], credentials)
 
           @errors = response.errors

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -1,352 +1,355 @@
 module NetSuite
-  module Configuration
-    extend self
+  class Configuration
+    module ConfigurationMethods
+      def reset!
+        NetSuite::Utilities.clear_cache!
+        clear_wsdl_cache
 
-    def reset!
-      NetSuite::Utilities.clear_cache!
-      clear_wsdl_cache
-
-      attributes.clear
-    end
-
-    def attributes
-      @attributes ||= {}
-    end
-
-    def connection(params={})
-      client = Savon.client({
-        wsdl: cached_wsdl || wsdl,
-        read_timeout: read_timeout,
-        namespaces: namespaces,
-        soap_header: auth_header.update(soap_header),
-        pretty_print_xml: true,
-        filters: filters,
-        logger: logger,
-        log_level: log_level,
-        log: !silent, # turn off logging entirely if configured
-      }.update(params))
-      cache_wsdl(client)
-      return client
-    end
-
-    def filters(list = nil)
-      if list
-        self.filters = list
-      else
-        attributes[:filters] ||= [
-          :password,
-          :email,
-          :consumerKey,
-          :token
-        ]
+        attributes.clear
       end
-    end
 
-    def filters=(list)
-      attributes[:filters] = list
-    end
-
-    def wsdl_cache
-      @wsdl_cache ||= {}
-    end
-
-    def clear_wsdl_cache
-      @wsdl_cache = {}
-    end
-
-    def cached_wsdl
-      cached = wsdl_cache.fetch([api_version, wsdl], nil)
-      if cached.is_a? String
-        cached
-      elsif cached.is_a? Savon::Client
-        wsdl_cache[[api_version, wsdl]] = cached.instance_eval { @wsdl.xml }
+      def attributes
+        @attributes ||= {}
       end
-    end
 
-    def cache_wsdl(client)
-      # NOTE the Savon::Client doesn't pull the wsdl content upon
-      # instantiation; it pulls it when it recieves the #call method.
-      # If we force it to pull the wsdl here, it will duplicate the call later.
-      # So, we stash the entire client and fetch just the wsdl from it after
-      # it completes its call
-      # For reference, see:
-      # https://github.com/savonrb/savon/blob/d64925d3add33fa5531577ce9e3a28a7a93618b1/lib/savon/client.rb#L35-L37
-      # https://github.com/savonrb/savon/blob/d64925d3add33fa5531577ce9e3a28a7a93618b1/lib/savon/operation.rb#L22
-      wsdl_cache[[api_version, wsdl]] ||= client
-    end
-
-    def api_version(version = nil)
-      if version
-        self.api_version = version
-      else
-        attributes[:api_version] ||= '2015_1'
+      def connection(params={})
+        client = Savon.client({
+          wsdl: cached_wsdl || wsdl,
+          read_timeout: read_timeout,
+          namespaces: namespaces,
+          soap_header: auth_header.update(soap_header),
+          pretty_print_xml: true,
+          filters: filters,
+          logger: logger,
+          log_level: log_level,
+          log: !silent, # turn off logging entirely if configured
+        }.update(params))
+        cache_wsdl(client)
+        return client
       end
-    end
 
-    def api_version=(version)
-      attributes[:api_version] = version
-    end
-
-    def sandbox=(flag)
-      attributes[:flag] = flag
-    end
-
-    def sandbox(flag = nil)
-      if flag.nil?
-        attributes[:flag] ||= false
-      else
-        self.sandbox = flag
+      def filters(list = nil)
+        if list
+          self.filters = list
+        else
+          attributes[:filters] ||= [
+            :password,
+            :email,
+            :consumerKey,
+            :token
+          ]
+        end
       end
-    end
 
-    def sandbox?
-      !!sandbox
-    end
+      def filters=(list)
+        attributes[:filters] = list
+      end
 
-    def wsdl=(wsdl)
-      attributes[:wsdl] = wsdl
-    end
+      def wsdl_cache
+        @wsdl_cache ||= {}
+      end
 
-    def wsdl(wsdl = nil)
-      if wsdl
-        self.wsdl = wsdl
-      else
-        attributes[:wsdl] ||= begin
-          if sandbox
-            "https://webservices.sandbox.netsuite.com/wsdl/v#{api_version}_0/netsuite.wsdl"
-          else
-            "https://#{wsdl_domain}/wsdl/v#{api_version}_0/netsuite.wsdl"
+      def clear_wsdl_cache
+        @wsdl_cache = {}
+      end
+
+      def cached_wsdl
+        cached = wsdl_cache.fetch([api_version, wsdl], nil)
+        if cached.is_a? String
+          cached
+        elsif cached.is_a? Savon::Client
+          wsdl_cache[[api_version, wsdl]] = cached.instance_eval { @wsdl.xml }
+        end
+      end
+
+      def cache_wsdl(client)
+        # NOTE the Savon::Client doesn't pull the wsdl content upon
+        # instantiation; it pulls it when it recieves the #call method.
+        # If we force it to pull the wsdl here, it will duplicate the call later.
+        # So, we stash the entire client and fetch just the wsdl from it after
+        # it completes its call
+        # For reference, see:
+        # https://github.com/savonrb/savon/blob/d64925d3add33fa5531577ce9e3a28a7a93618b1/lib/savon/client.rb#L35-L37
+        # https://github.com/savonrb/savon/blob/d64925d3add33fa5531577ce9e3a28a7a93618b1/lib/savon/operation.rb#L22
+        wsdl_cache[[api_version, wsdl]] ||= client
+      end
+
+      def api_version(version = nil)
+        if version
+          self.api_version = version
+        else
+          attributes[:api_version] ||= '2015_1'
+        end
+      end
+
+      def api_version=(version)
+        attributes[:api_version] = version
+      end
+
+      def sandbox=(flag)
+        attributes[:flag] = flag
+      end
+
+      def sandbox(flag = nil)
+        if flag.nil?
+          attributes[:flag] ||= false
+        else
+          self.sandbox = flag
+        end
+      end
+
+      def sandbox?
+        !!sandbox
+      end
+
+      def wsdl=(wsdl)
+        attributes[:wsdl] = wsdl
+      end
+
+      def wsdl(wsdl = nil)
+        if wsdl
+          self.wsdl = wsdl
+        else
+          attributes[:wsdl] ||= begin
+            if sandbox
+              "https://webservices.sandbox.netsuite.com/wsdl/v#{api_version}_0/netsuite.wsdl"
+            else
+              "https://#{wsdl_domain}/wsdl/v#{api_version}_0/netsuite.wsdl"
+            end
           end
         end
       end
-    end
 
-    def wsdl_domain(wsdl_domain = nil)
-      if wsdl_domain
-        self.wsdl_domain = wsdl_domain
-      else
-        # if sandbox, this parameter is ignored
-        if sandbox
-          'webservices.sandbox.netsuite.com'
+      def wsdl_domain(wsdl_domain = nil)
+        if wsdl_domain
+          self.wsdl_domain = wsdl_domain
         else
-          attributes[:wsdl_domain] ||= 'webservices.netsuite.com'
+          # if sandbox, this parameter is ignored
+          if sandbox
+            'webservices.sandbox.netsuite.com'
+          else
+            attributes[:wsdl_domain] ||= 'webservices.netsuite.com'
+          end
         end
       end
-    end
 
-    def wsdl_domain=(wsdl_domain)
-      attributes[:wsdl_domain] = wsdl_domain
-    end
-
-    def soap_header=(headers)
-      attributes[:soap_header] = headers
-    end
-
-    def soap_header(headers = nil)
-      if headers
-        self.soap_header = headers
-      else
-        attributes[:soap_header] ||= {}
+      def wsdl_domain=(wsdl_domain)
+        attributes[:wsdl_domain] = wsdl_domain
       end
-    end
 
-    def auth_header(credentials={})
-      if !credentials[:consumer_key].blank? || !consumer_key.blank?
-        token_auth(credentials)
-      else
-        user_auth(credentials)
+      def soap_header=(headers)
+        attributes[:soap_header] = headers
       end
-    end
 
-    def user_auth(credentials)
-      NetSuite::Passports::User.new(
-        credentials[:account] || account,
-        credentials[:email] || email,
-        credentials[:password] || password,
-        credentials[:role] || role
-      ).passport
-    end
-
-    def token_auth(credentials)
-      NetSuite::Passports::Token.new(
-        credentials[:account] || account,
-        credentials[:consumer_key] || consumer_key,
-        credentials[:consumer_secret] || consumer_secret,
-        credentials[:token_id] || token_id,
-        credentials[:token_secret] || token_secret
-      ).passport
-    end
-
-    def namespaces
-      {
-        'xmlns:platformMsgs'   => "urn:messages_#{api_version}.platform.webservices.netsuite.com",
-        'xmlns:platformCore'   => "urn:core_#{api_version}.platform.webservices.netsuite.com",
-        'xmlns:platformCommon' => "urn:common_#{api_version}.platform.webservices.netsuite.com",
-        'xmlns:listRel'        => "urn:relationships_#{api_version}.lists.webservices.netsuite.com",
-        'xmlns:tranSales'      => "urn:sales_#{api_version}.transactions.webservices.netsuite.com",
-        'xmlns:tranPurch'      => "urn:purchases_#{api_version}.transactions.webservices.netsuite.com",
-        'xmlns:actSched'       => "urn:scheduling_#{api_version}.activities.webservices.netsuite.com",
-        'xmlns:setupCustom'    => "urn:customization_#{api_version}.setup.webservices.netsuite.com",
-        'xmlns:listAcct'       => "urn:accounting_#{api_version}.lists.webservices.netsuite.com",
-        'xmlns:tranBank'       => "urn:bank_#{api_version}.transactions.webservices.netsuite.com",
-        'xmlns:tranCust'       => "urn:customers_#{api_version}.transactions.webservices.netsuite.com",
-        'xmlns:tranEmp'        => "urn:employees_#{api_version}.transactions.webservices.netsuite.com",
-        'xmlns:tranInvt'       => "urn:inventory_#{api_version}.transactions.webservices.netsuite.com",
-        'xmlns:listSupport'    => "urn:support_#{api_version}.lists.webservices.netsuite.com",
-        'xmlns:tranGeneral'    => "urn:general_#{api_version}.transactions.webservices.netsuite.com",
-        'xmlns:commGeneral'    => "urn:communication_#{api_version}.general.webservices.netsuite.com",
-        'xmlns:listMkt'        => "urn:marketing_#{api_version}.lists.webservices.netsuite.com",
-        'xmlns:listWebsite'    => "urn:website_#{api_version}.lists.webservices.netsuite.com",
-        'xmlns:fileCabinet'    => "urn:filecabinet_#{api_version}.documents.webservices.netsuite.com",
-        'xmlns:listEmp'        => "urn:employees_#{api_version}.lists.webservices.netsuite.com"
-      }
-    end
-
-    def role=(role)
-      attributes[:role] = role
-    end
-
-    def role(role = nil)
-      if role
-        self.role = role
-      else
-        attributes[:role] ||= '3'
+      def soap_header(headers = nil)
+        if headers
+          self.soap_header = headers
+        else
+          attributes[:soap_header] ||= {}
+        end
       end
-    end
 
-    def email=(email)
-      attributes[:email] = email
-    end
-
-    def email(email = nil)
-      if email
-        self.email = email
-      else
-        attributes[:email]
+      def auth_header(credentials={})
+        if !credentials[:consumer_key].blank? || !consumer_key.blank?
+          token_auth(credentials)
+        else
+          user_auth(credentials)
+        end
       end
-    end
 
-    def password=(password)
-      attributes[:password] = password
-    end
-
-    def password(password = nil)
-      if password
-        self.password = password
-      else
-        attributes[:password]
+      def user_auth(credentials)
+        NetSuite::Passports::User.new(
+          credentials[:account] || account,
+          credentials[:email] || email,
+          credentials[:password] || password,
+          credentials[:role] || role
+        ).passport
       end
-    end
 
-    def account=(account)
-      attributes[:account] = account
-    end
-
-    def account(account = nil)
-      if account
-        self.account = account
-      else
-        attributes[:account]
+      def token_auth(credentials)
+        NetSuite::Passports::Token.new(
+          credentials[:account] || account,
+          credentials[:consumer_key] || consumer_key,
+          credentials[:consumer_secret] || consumer_secret,
+          credentials[:token_id] || token_id,
+          credentials[:token_secret] || token_secret
+        ).passport
       end
-    end
 
-    def consumer_key=(consumer_key)
-      attributes[:consumer_key] = consumer_key
-    end
-
-    def consumer_key(consumer_key = nil)
-      if consumer_key
-        self.consumer_key = consumer_key
-      else
-        attributes[:consumer_key]
+      def namespaces
+        {
+          'xmlns:platformMsgs'   => "urn:messages_#{api_version}.platform.webservices.netsuite.com",
+          'xmlns:platformCore'   => "urn:core_#{api_version}.platform.webservices.netsuite.com",
+          'xmlns:platformCommon' => "urn:common_#{api_version}.platform.webservices.netsuite.com",
+          'xmlns:listRel'        => "urn:relationships_#{api_version}.lists.webservices.netsuite.com",
+          'xmlns:tranSales'      => "urn:sales_#{api_version}.transactions.webservices.netsuite.com",
+          'xmlns:tranPurch'      => "urn:purchases_#{api_version}.transactions.webservices.netsuite.com",
+          'xmlns:actSched'       => "urn:scheduling_#{api_version}.activities.webservices.netsuite.com",
+          'xmlns:setupCustom'    => "urn:customization_#{api_version}.setup.webservices.netsuite.com",
+          'xmlns:listAcct'       => "urn:accounting_#{api_version}.lists.webservices.netsuite.com",
+          'xmlns:tranBank'       => "urn:bank_#{api_version}.transactions.webservices.netsuite.com",
+          'xmlns:tranCust'       => "urn:customers_#{api_version}.transactions.webservices.netsuite.com",
+          'xmlns:tranEmp'        => "urn:employees_#{api_version}.transactions.webservices.netsuite.com",
+          'xmlns:tranInvt'       => "urn:inventory_#{api_version}.transactions.webservices.netsuite.com",
+          'xmlns:listSupport'    => "urn:support_#{api_version}.lists.webservices.netsuite.com",
+          'xmlns:tranGeneral'    => "urn:general_#{api_version}.transactions.webservices.netsuite.com",
+          'xmlns:commGeneral'    => "urn:communication_#{api_version}.general.webservices.netsuite.com",
+          'xmlns:listMkt'        => "urn:marketing_#{api_version}.lists.webservices.netsuite.com",
+          'xmlns:listWebsite'    => "urn:website_#{api_version}.lists.webservices.netsuite.com",
+          'xmlns:fileCabinet'    => "urn:filecabinet_#{api_version}.documents.webservices.netsuite.com",
+          'xmlns:listEmp'        => "urn:employees_#{api_version}.lists.webservices.netsuite.com"
+        }
       end
-    end
 
-    def consumer_secret=(consumer_secret)
-      attributes[:consumer_secret] = consumer_secret
-    end
-
-    def consumer_secret(consumer_secret = nil)
-      if consumer_secret
-        self.consumer_secret = consumer_secret
-      else
-        attributes[:consumer_secret]
+      def role=(role)
+        attributes[:role] = role
       end
-    end
 
-    def token_id=(token_id)
-      attributes[:token_id] = token_id
-    end
-
-    def token_id(token_id = nil)
-      if token_id
-        self.token_id = token_id
-      else
-        attributes[:token_id]
+      def role(role = nil)
+        if role
+          self.role = role
+        else
+          attributes[:role] ||= '3'
+        end
       end
-    end
 
-    def token_secret=(token_secret)
-      attributes[:token_secret] = token_secret
-    end
-
-    def token_secret(token_secret = nil)
-      if token_secret
-        self.token_secret = token_secret
-      else
-        attributes[:token_secret]
+      def email=(email)
+        attributes[:email] = email
       end
-    end
 
-    def read_timeout=(timeout)
-      attributes[:read_timeout] = timeout
-    end
-
-    def read_timeout(timeout = nil)
-      if timeout
-        self.read_timeout = timeout
-      else
-        attributes[:read_timeout] ||= 60
+      def email(email = nil)
+        if email
+          self.email = email
+        else
+          attributes[:email]
+        end
       end
-    end
 
-    def log=(path)
-      attributes[:log] = path
-    end
+      def password=(password)
+        attributes[:password] = password
+      end
 
-    def log(path = nil)
-      self.log = path if path
-      attributes[:log]
-    end
+      def password(password = nil)
+        if password
+          self.password = password
+        else
+          attributes[:password]
+        end
+      end
 
-    def logger(value = nil)
-      if value.nil?
-        attributes[:logger] ||= ::Logger.new((log && !log.empty?) ? log : $stdout)
-      else
+      def account=(account)
+        attributes[:account] = account
+      end
+
+      def account(account = nil)
+        if account
+          self.account = account
+        else
+          attributes[:account]
+        end
+      end
+
+      def consumer_key=(consumer_key)
+        attributes[:consumer_key] = consumer_key
+      end
+
+      def consumer_key(consumer_key = nil)
+        if consumer_key
+          self.consumer_key = consumer_key
+        else
+          attributes[:consumer_key]
+        end
+      end
+
+      def consumer_secret=(consumer_secret)
+        attributes[:consumer_secret] = consumer_secret
+      end
+
+      def consumer_secret(consumer_secret = nil)
+        if consumer_secret
+          self.consumer_secret = consumer_secret
+        else
+          attributes[:consumer_secret]
+        end
+      end
+
+      def token_id=(token_id)
+        attributes[:token_id] = token_id
+      end
+
+      def token_id(token_id = nil)
+        if token_id
+          self.token_id = token_id
+        else
+          attributes[:token_id]
+        end
+      end
+
+      def token_secret=(token_secret)
+        attributes[:token_secret] = token_secret
+      end
+
+      def token_secret(token_secret = nil)
+        if token_secret
+          self.token_secret = token_secret
+        else
+          attributes[:token_secret]
+        end
+      end
+
+      def read_timeout=(timeout)
+        attributes[:read_timeout] = timeout
+      end
+
+      def read_timeout(timeout = nil)
+        if timeout
+          self.read_timeout = timeout
+        else
+          attributes[:read_timeout] ||= 60
+        end
+      end
+
+      def log=(path)
+        attributes[:log] = path
+      end
+
+      def log(path = nil)
+        self.log = path if path
+        attributes[:log]
+      end
+
+      def logger(value = nil)
+        if value.nil?
+          attributes[:logger] ||= ::Logger.new((log && !log.empty?) ? log : $stdout)
+        else
+          attributes[:logger] = value
+        end
+      end
+
+      def logger=(value)
         attributes[:logger] = value
       end
+
+      def silent(value=nil)
+        self.silent = value if !value.nil?
+        attributes[:silent]
+      end
+
+      def silent=(value)
+        attributes[:silent] ||= value
+      end
+
+      def log_level(value = nil)
+        self.log_level = value || :debug
+        attributes[:log_level]
+      end
+
+      def log_level=(value)
+        attributes[:log_level] ||= value
+      end
     end
 
-    def logger=(value)
-      attributes[:logger] = value
-    end
-
-    def silent(value=nil)
-      self.silent = value if !value.nil?
-      attributes[:silent]
-    end
-
-    def silent=(value)
-      attributes[:silent] ||= value
-    end
-
-    def log_level(value = nil)
-      self.log_level = value || :debug
-      attributes[:log_level]
-    end
-
-    def log_level=(value)
-      attributes[:log_level] ||= value
-    end
+    extend NetSuite::Configuration::ConfigurationMethods
+    include NetSuite::Configuration::ConfigurationMethods
   end
 end

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -13,12 +13,12 @@ module NetSuite
       @attributes ||= {}
     end
 
-    def connection(params={}, credentials={})
+    def connection(params={})
       client = Savon.client({
         wsdl: cached_wsdl || wsdl,
         read_timeout: read_timeout,
         namespaces: namespaces,
-        soap_header: auth_header(credentials).update(soap_header),
+        soap_header: auth_header.update(soap_header),
         pretty_print_xml: true,
         filters: filters,
         logger: logger,

--- a/lib/netsuite/support/requests.rb
+++ b/lib/netsuite/support/requests.rb
@@ -8,15 +8,16 @@ module NetSuite
 
       module ClassMethods
 
-        def call(options, credentials={})
+        def call(options, configuration = nil)
           raise ArgumentError, "options should be an array" unless options.is_a?(Array)
-          new(*options).call(credentials)
+          # TODO detect invalid configuration type
+          new(*options).call(configuration)
         end
 
       end
 
-      def call(credentials={})
-        @response = request(credentials)
+      def call(configuration = nil)
+        @response = request(configuration)
         build_response
       end
 
@@ -47,6 +48,7 @@ module NetSuite
         raise NotImplementedError, 'Please implement a #response_body method'
       end
 
+      # TODO DRY this up -- pretty sure this pattern is used elsewhere in the codebase
       def array_wrap(object)
         if object.is_a?(Array)
           return object


### PR DESCRIPTION
Passing a credentials hash doesn't work. There are too many configuration options (oauth, wsdl, api version, logging, etc).

Instead, we should allow the entire configuration object to be passed as an optional parameter

---

- [ ] investigate if there is any downside to removing namespaces
- [ ] rework wsdl cache into higher level abstraction