### PR TITLE
Remove errant `include`

### DIFF
--- a/lib/netsuite/records/item_member.rb
+++ b/lib/netsuite/records/item_member.rb
@@ -13,7 +13,12 @@ module NetSuite
       record_refs :tax_schedule, :item, :effective_revision,
         :obsolete_revision
 
+      attr_reader :internal_id
+      attr_accessor :external_id
+
       def initialize(attributes = {})
+        @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
+        @external_id = attributes.delete(:external_id) || attributes.delete(:@external_id)
         initialize_from_attributes_hash(attributes)
       end
     end

--- a/lib/netsuite/records/member_list.rb
+++ b/lib/netsuite/records/member_list.rb
@@ -1,7 +1,6 @@
 module NetSuite
   module Records
     class MemberList < Support::Sublist
-      include Support::Records
       include Namespaces::ListAcct
 
       fields :replace_all


### PR DESCRIPTION
`Support::Records` also implements `to_record`, which overrides the
implementation in `Support::Sublist`.  This causes the items on the
member list to be ommited in the request body.