### PR TITLE
Add missing klass attribute to inventory transfers

### DIFF
--- a/lib/netsuite/records/inventory_transfer.rb
+++ b/lib/netsuite/records/inventory_transfer.rb
@@ -9,10 +9,10 @@ module NetSuite
 
       actions :get, :add, :delete, :search, :update, :upsert, :upsert_list
 
-      fields :created_date, :last_modified_date, :tran_date, :tran_id, :memo
+      fields :klass, :created_date, :last_modified_date, :tran_date, :tran_id, :memo
 
       field :inventory_list, InventoryTransferInventoryList
-      
+
       record_refs :posting_period, :location, :transfer_location, :department,
         :subsidiary
 


### PR DESCRIPTION
```
[1] pry(main)> NetSuite::Records::InventoryTransfer.get(1234)
NoMethodError: undefined method `klass=' for #<NetSuite::Records::InventoryTransfer:0x0055d5407d88e8>
```