### PR TITLE
Fix the #to_record method on inventory lists

### DIFF
--- a/lib/netsuite/records/inventory_transfer_inventory_list.rb
+++ b/lib/netsuite/records/inventory_transfer_inventory_list.rb
@@ -1,8 +1,6 @@
 module NetSuite
   module Records
     class InventoryTransferInventoryList < Support::Sublist
-      include Support::RecordRefs
-      include Support::Records
       include Namespaces::TranInvt
 
       sublist :inventory, InventoryTransferInventory

--- a/spec/netsuite/records/inventory_transfer_spec.rb
+++ b/spec/netsuite/records/inventory_transfer_spec.rb
@@ -19,6 +19,27 @@ describe NetSuite::Records::InventoryTransfer do
     end
   end
 
+  describe '#to_record' do
+    it 'includes the inventory_list' do
+      attributes = {
+        :inventory => [{
+          :inventory_detail => {
+            :custom_form => {
+              internal_id: 1
+            },
+            :inventory_assignment_list => {
+              :inventory_assignment => [{
+                quantity: 3
+              }]
+            }
+          }
+        }]
+      }
+      inventory_transfer.inventory_list = attributes
+      list = inventory_transfer.to_record.fetch("tranInvt:inventoryList").fetch("tranInvt:inventory")
+      expect(list.count).to eq(1)
+    end
+  end
 
   describe '#inventory_list' do
     it 'can be set from attributes' do


### PR DESCRIPTION
I observed the `to_record` method leaving off all items from the item list.