### PR TITLE
Support class attribute in InventoryAdjustment

### DIFF
--- a/lib/netsuite/records/inventory_adjustment.rb
+++ b/lib/netsuite/records/inventory_adjustment.rb
@@ -15,7 +15,7 @@ module NetSuite
       field :custom_field_list, CustomFieldList
       
       record_refs :account, :adj_location, :customer, :posting_period, :location, :department,
-        :subsidiary, :custom_form
+        :subsidiary, :custom_form, :klass
 
       attr_reader :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/inventory_adjustment_inventory.rb
+++ b/lib/netsuite/records/inventory_adjustment_inventory.rb
@@ -11,7 +11,7 @@ module NetSuite
 
       field :inventory_detail, InventoryDetail
 
-      record_refs :item, :units, :location
+      record_refs :item, :units, :location, :klass
 
       def initialize(attributes = {})
         initialize_from_attributes_hash(attributes)


### PR DESCRIPTION
Element InventoryAdjustment now has a class RecordRef. See https://webservices.netsuite.com/xsd/transactions/v2017_1_0/inventory.xsd on line 24

Without the `:klass` record ref, I get an error when loading an inventory adjustment record with API 2017_1.