### PR TITLE
Allow errors to be represented as strings

### DIFF
--- a/lib/netsuite/errors.rb
+++ b/lib/netsuite/errors.rb
@@ -11,5 +11,7 @@ module NetSuite
       @code    = args[:code]
       @message = args[:message]
     end
+
+    alias_method :to_s, :inspect
   end
 end


### PR DESCRIPTION
Changes viewing errors in honeybadger from

`"#<NetSuite::Error:0x0055a605e61e90>"`

to

`"ERROR USER_ERROR You cannot edit the end of group line.  You must
delete the group."`

Which is helpful for debugging

Fixes: #343