### PR TITLE
Added search_joins to NetSuite::Records::Contact

### DIFF
--- a/lib/netsuite/records/contact.rb
+++ b/lib/netsuite/records/contact.rb
@@ -24,6 +24,7 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
+      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)


### PR DESCRIPTION
I believe search_joins should be a part of this class if it is to work properly with the public class method search.