### PR TITLE
Addressbook and Employee Record Updates

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -66,6 +66,8 @@ module NetSuite
   end
 
   module Records
+    autoload :Addressbook,                      'netsuite/records/addressbook'
+    autoload :AddressbookList,                  'netsuite/records/addressbook_list'
     autoload :AssemblyItem,                     'netsuite/records/assembly_item'
     autoload :AssemblyBuild,                    'netsuite/records/assembly_build'
     autoload :AssemblyComponent,                'netsuite/records/assembly_component'
@@ -148,6 +150,8 @@ module NetSuite
     autoload :DiscountItem,                     'netsuite/records/discount_item'
     autoload :Duration,                         'netsuite/records/duration'
     autoload :Employee,                         'netsuite/records/employee'
+    autoload :EmployeeAddressbook,              'netsuite/records/employee_addressbook'
+    autoload :EmployeeAddressbookList,          'netsuite/records/employee_addressbook_list'
     autoload :File,                             'netsuite/records/file'
     autoload :GiftCertificate,                  'netsuite/records/gift_certificate'
     autoload :GiftCertificateItem,              'netsuite/records/gift_certificate_item'

--- a/lib/netsuite/records/addressbook.rb
+++ b/lib/netsuite/records/addressbook.rb
@@ -1,0 +1,64 @@
+module NetSuite
+  module Records
+    class Addressbook
+      include Support::Fields
+      include Support::Records
+      include Namespaces::ListRel
+
+      # address implementation changed
+      # https://github.com/NetSweet/netsuite/pull/213
+
+      # https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2015_1/schema/other/customeraddressbook.html?mode=package
+
+      fields :default_shipping, :default_billing, :is_residential, :label, :internal_id
+
+      # NOTE API < 2014_2
+      fields :attention, :addressee, :phone, :addr1, :addr2, :addr3, :city, :zip, :override, :state
+      field :country, NetSuite::Support::Country
+      read_only_fields :addr_text
+
+      # NOTE API >= 2014_2
+      field :addressbook_address, NetSuite::Records::Address
+
+      def initialize(attributes_or_record = {})
+        case attributes_or_record
+        when self.class
+          initialize_from_record(attributes_or_record)
+        when Hash
+          attributes_or_record = attributes_or_record[:addressbook] if attributes_or_record[:addressbook]
+          initialize_from_attributes_hash(attributes_or_record)
+        end
+      end
+
+      def initialize_from_record(obj)
+        if NetSuite::Configuration.api_version < "2014_2"
+          self.default_shipping = obj.default_shipping
+          self.default_billing  = obj.default_billing
+          self.is_residential   = obj.is_residential
+          self.label            = obj.label
+          self.attention        = obj.attention
+          self.addressee        = obj.addressee
+          self.phone            = obj.phone
+          self.addr1            = obj.addr1
+          self.addr2            = obj.addr2
+          self.addr3            = obj.addr3
+          self.city             = obj.city
+          self.zip              = obj.zip
+          self.country          = obj.country
+          self.addr_text        = obj.addr_text
+          self.override         = obj.override
+          self.state            = obj.state
+          self.internal_id      = obj.internal_id
+        else
+          self.addressbook_address = obj.addressbook_address
+          self.default_billing  = obj.default_billing
+          self.default_shipping = obj.default_shipping
+          self.internal_id      = obj.internal_id
+          self.is_residential   = obj.is_residential
+          self.label            = obj.label
+        end
+      end
+
+    end
+  end
+end

--- a/lib/netsuite/records/addressbook_list.rb
+++ b/lib/netsuite/records/addressbook_list.rb
@@ -1,0 +1,14 @@
+module NetSuite
+  module Records
+    class AddressbookList < Support::Sublist
+      include Namespaces::ListRel
+      include Support::Actions
+
+      actions :get
+
+      sublist :addressbook, Addressbook
+
+      alias :addressbooks :addressbook
+    end
+  end
+end

--- a/lib/netsuite/records/contact_addressbook.rb
+++ b/lib/netsuite/records/contact_addressbook.rb
@@ -1,64 +1,6 @@
 module NetSuite
   module Records
-    class ContactAddressbook
-      include Support::Fields
-      include Support::Records
-      include Namespaces::ListRel
-
-      # address implementation changed
-      # https://github.com/NetSweet/netsuite/pull/213
-
-      # https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2015_1/schema/other/customeraddressbook.html?mode=package
-
-      fields :default_shipping, :default_billing, :is_residential, :label, :internal_id
-
-      # NOTE API < 2014_2
-      fields :attention, :addressee, :phone, :addr1, :addr2, :addr3, :city, :zip, :override, :state
-      field :country, NetSuite::Support::Country
-      read_only_fields :addr_text
-
-      # NOTE API >= 2014_2
-      field :addressbook_address, NetSuite::Records::Address
-
-      def initialize(attributes_or_record = {})
-        case attributes_or_record
-        when self.class
-          initialize_from_record(attributes_or_record)
-        when Hash
-          attributes_or_record = attributes_or_record[:addressbook] if attributes_or_record[:addressbook]
-          initialize_from_attributes_hash(attributes_or_record)
-        end
-      end
-
-      def initialize_from_record(obj)
-        if NetSuite::Configuration.api_version < "2014_2"
-          self.default_shipping = obj.default_shipping
-          self.default_billing  = obj.default_billing
-          self.is_residential   = obj.is_residential
-          self.label            = obj.label
-          self.attention        = obj.attention
-          self.addressee        = obj.addressee
-          self.phone            = obj.phone
-          self.addr1            = obj.addr1
-          self.addr2            = obj.addr2
-          self.addr3            = obj.addr3
-          self.city             = obj.city
-          self.zip              = obj.zip
-          self.country          = obj.country
-          self.addr_text        = obj.addr_text
-          self.override         = obj.override
-          self.state            = obj.state
-          self.internal_id      = obj.internal_id
-        else
-          self.addressbook_address = obj.addressbook_address
-          self.default_billing  = obj.default_billing
-          self.default_shipping = obj.default_shipping
-          self.internal_id      = obj.internal_id
-          self.is_residential   = obj.is_residential
-          self.label            = obj.label
-        end
-      end
-
+    class ContactAddressbook < NetSuite::Records::Addressbook
     end
   end
 end

--- a/lib/netsuite/records/contact_addressbook_list.rb
+++ b/lib/netsuite/records/contact_addressbook_list.rb
@@ -1,8 +1,6 @@
 module NetSuite
   module Records
-    class ContactAddressbookList < Support::Sublist
-      include Namespaces::ListRel
-
+    class ContactAddressbookList < NetSuite::Records::AddressbookList
       sublist :addressbook, ContactAddressbook
 
       alias :addressbooks :addressbook

--- a/lib/netsuite/records/customer_addressbook.rb
+++ b/lib/netsuite/records/customer_addressbook.rb
@@ -1,64 +1,6 @@
 module NetSuite
   module Records
-    class CustomerAddressbook
-      include Support::Fields
-      include Support::Records
-      include Namespaces::ListRel
-
-      # address implementation changed
-      # https://github.com/NetSweet/netsuite/pull/213
-
-      # https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2015_1/schema/other/customeraddressbook.html?mode=package
-
-      fields :default_shipping, :default_billing, :is_residential, :label, :internal_id
-
-      # NOTE API < 2014_2
-      fields :attention, :addressee, :phone, :addr1, :addr2, :addr3, :city, :zip, :override, :state
-      field :country, NetSuite::Support::Country
-      read_only_fields :addr_text
-
-      # NOTE API >= 2014_2
-      field :addressbook_address, NetSuite::Records::Address
-
-      def initialize(attributes_or_record = {})
-        case attributes_or_record
-        when self.class
-          initialize_from_record(attributes_or_record)
-        when Hash
-          attributes_or_record = attributes_or_record[:addressbook] if attributes_or_record[:addressbook]
-          initialize_from_attributes_hash(attributes_or_record)
-        end
-      end
-
-      def initialize_from_record(obj)
-        if NetSuite::Configuration.api_version < "2014_2"
-          self.default_shipping = obj.default_shipping
-          self.default_billing  = obj.default_billing
-          self.is_residential   = obj.is_residential
-          self.label            = obj.label
-          self.attention        = obj.attention
-          self.addressee        = obj.addressee
-          self.phone            = obj.phone
-          self.addr1            = obj.addr1
-          self.addr2            = obj.addr2
-          self.addr3            = obj.addr3
-          self.city             = obj.city
-          self.zip              = obj.zip
-          self.country          = obj.country
-          self.addr_text        = obj.addr_text
-          self.override         = obj.override
-          self.state            = obj.state
-          self.internal_id      = obj.internal_id
-        else
-          self.addressbook_address = obj.addressbook_address
-          self.default_billing  = obj.default_billing
-          self.default_shipping = obj.default_shipping
-          self.internal_id      = obj.internal_id
-          self.is_residential   = obj.is_residential
-          self.label            = obj.label
-        end
-      end
-
+    class CustomerAddressbook < NetSuite::Records::Addressbook
     end
   end
 end

--- a/lib/netsuite/records/customer_addressbook_list.rb
+++ b/lib/netsuite/records/customer_addressbook_list.rb
@@ -1,8 +1,6 @@
 module NetSuite
   module Records
-    class CustomerAddressbookList < Support::Sublist
-      include Namespaces::ListRel
-
+    class CustomerAddressbookList < NetSuite::Records::AddressbookList
       sublist :addressbook, CustomerAddressbook
 
       alias :addressbooks :addressbook

--- a/lib/netsuite/records/employee.rb
+++ b/lib/netsuite/records/employee.rb
@@ -89,6 +89,7 @@ module NetSuite
 
       record_refs *RECORD_REFS
 
+      field :addressbook_list,  EmployeeAddressbookList
       field :custom_field_list, CustomFieldList
       field :roles_list, RoleList
 

--- a/lib/netsuite/records/employee.rb
+++ b/lib/netsuite/records/employee.rb
@@ -9,85 +9,23 @@ module NetSuite
 
       # https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2014_1/script/record/employee.html
 
-      ACTIONS = %w{
-        add
-        delete
-        get
-        get_list
-        search
-        update
-        upsert
-        upsert_list
-      }.map(&:to_sym).freeze
+      actions :add, :delete, :get, :get_list, :search, :update, :upsert, :upsert_list
 
-      actions *ACTIONS
+      fields :account_number, :alien_number, :alt_name, :approval_limit,
+        :bill_pay, :birth_date, :comments, :date_created, :default_address,
+        :direct_deposit, :eligible_for_commission, :email, :entity_id,
+        :expense_limit, :fax, :first_name, :gender, :give_access, :hire_date,
+        :home_phone, :is_inactive, :is_job_resource, :is_sales_rep,
+        :is_support_rep, :job_description, :klass, :labor_cost,
+        :last_modified_date, :last_name, :last_review_date, :middle_name,
+        :mobile_phone, :next_review_date, :office_phone, :password, :password2,
+        :pay_frequency, :phone, :phonetic_name, :purchase_order_approval_limit,
+        :purchase_order_approver, :purchase_order_limit, :release_date,
+        :resident_status, :salutation, :send_email, :social_security_number,
+        :title, :visa_exp_date, :visa_type
 
-      FIELDS = %w{
-        account_number
-        alien_number
-        alt_name
-        approval_limit
-        bill_pay
-        birth_date
-        comments
-        date_created
-        default_address
-        direct_deposit
-        eligible_for_commission
-        email
-        entity_id
-        expense_limit
-        fax
-        first_name
-        gender
-        give_access
-        hire_date
-        home_phone
-        is_inactive
-        is_job_resource
-        is_sales_rep
-        is_support_rep
-        job_description
-        klass
-        labor_cost
-        last_modified_date
-        last_name
-        last_review_date
-        middle_name
-        mobile_phone
-        next_review_date
-        office_phone
-        password
-        password2
-        pay_frequency
-        phone
-        phonetic_name
-        purchase_order_approval_limit
-        purchase_order_approver
-        purchase_order_limit
-        release_date
-        resident_status
-        salutation
-        send_email
-        social_security_number
-        title
-        visa_exp_date
-        visa_type
-      }.map(&:to_sym).freeze
-
-      fields *FIELDS
-
-      RECORD_REFS = %w{
-        currency
-        department
-        employee_status
-        employee_type
-        location
-        subsidiary
-        supervisor
-      }.map(&:to_sym).freeze
-
-      record_refs *RECORD_REFS
+      record_refs :currency, :department, :employee_status, :employee_type,
+        :location, :subsidiary, :supervisor
 
       field :addressbook_list,  EmployeeAddressbookList
       field :custom_field_list, CustomFieldList

--- a/lib/netsuite/records/employee.rb
+++ b/lib/netsuite/records/employee.rb
@@ -9,17 +9,83 @@ module NetSuite
 
       # https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2014_1/script/record/employee.html
 
-      actions :get, :get_list, :add, :update, :upsert, :upsert_list, :delete, :search
+      ACTIONS = %w{
+        add
+        delete
+        get
+        get_list
+        search
+        update
+        upsert
+        upsert_list
+      }.map(&:to_sym).freeze
 
-      fields :alt_name, :phone, :first_name, :last_name, :is_inactive, :email, :give_access, :send_email, :is_support_rep,
-             :birth_date, :hire_date, :last_review_date, :next_review_date, :title, :home_phone, :office_phone,
-             :eligible_for_commission, :is_sales_rep, :klass, :middle_name, :account_number, :alien_number, :approval_limit,
-             :bill_pay, :comments, :date_created, :direct_deposit, :entity_id, :password, :password2,
-             :expense_limit, :fax, :is_job_resource, :job_description, :labor_cost, :last_modified_date, :mobile_phone, :pay_frequency,
-             :phonetic_name, :purchase_order_approval_limit, :purchase_order_approver, :purchase_order_limit, :release_date,
-             :resident_status, :salutation, :social_security_number, :visa_exp_date, :visa_type
+      actions *ACTIONS
 
-      record_refs :currency, :department, :location, :subsidiary, :employee_type, :employee_status, :supervisor
+      FIELDS = %w{
+        account_number
+        alien_number
+        alt_name
+        approval_limit
+        bill_pay
+        birth_date
+        comments
+        date_created
+        direct_deposit
+        eligible_for_commission
+        email
+        entity_id
+        expense_limit
+        fax
+        first_name
+        give_access
+        hire_date
+        home_phone
+        is_inactive
+        is_job_resource
+        is_sales_rep
+        is_support_rep
+        job_description
+        klass
+        labor_cost
+        last_modified_date
+        last_name
+        last_review_date
+        middle_name
+        mobile_phone
+        next_review_date
+        office_phone
+        password
+        password2
+        pay_frequency
+        phone
+        phonetic_name
+        purchase_order_approval_limit
+        purchase_order_approver
+        purchase_order_limit
+        release_date
+        resident_status
+        salutation
+        send_email
+        social_security_number
+        title
+        visa_exp_date
+        visa_type
+      }.map(&:to_sym).freeze
+
+      fields *FIELDS
+
+      RECORD_REFS = %w{
+        currency
+        department
+        employee_status
+        employee_type
+        location
+        subsidiary
+        supervisor
+      }.map(&:to_sym).freeze
+
+      record_refs *RECORD_REFS
 
       field :custom_field_list, CustomFieldList
       field :roles_list, RoleList

--- a/lib/netsuite/records/employee.rb
+++ b/lib/netsuite/records/employee.rb
@@ -31,6 +31,7 @@ module NetSuite
         birth_date
         comments
         date_created
+        default_address
         direct_deposit
         eligible_for_commission
         email
@@ -38,6 +39,7 @@ module NetSuite
         expense_limit
         fax
         first_name
+        gender
         give_access
         hire_date
         home_phone
@@ -103,6 +105,13 @@ module NetSuite
         'Employee'
       end
 
+      def to_record
+        rec = super
+        if rec["#{record_namespace}:customFieldList"]
+          rec["#{record_namespace}:customFieldList!"] = rec.delete("#{record_namespace}:customFieldList")
+        end
+        rec
+      end
     end
   end
 end

--- a/lib/netsuite/records/employee_addressbook.rb
+++ b/lib/netsuite/records/employee_addressbook.rb
@@ -1,0 +1,6 @@
+module NetSuite
+  module Records
+    class EmployeeAddressbook < NetSuite::Records::Addressbook
+    end
+  end
+end

--- a/lib/netsuite/records/employee_addressbook_list.rb
+++ b/lib/netsuite/records/employee_addressbook_list.rb
@@ -1,0 +1,9 @@
+module NetSuite
+  module Records
+    class EmployeeAddressbookList < NetSuite::Records::AddressbookList
+      sublist :addressbook, EmployeeAddressbook
+
+      alias :addressbooks :addressbook
+    end
+  end
+end

--- a/spec/netsuite/records/addressbook_list_spec.rb
+++ b/spec/netsuite/records/addressbook_list_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe NetSuite::Records::CustomerAddressbookList do
-  let(:list) { NetSuite::Records::CustomerAddressbookList.new }
+describe NetSuite::Records::AddressbookList do
+  let(:list) { NetSuite::Records::AddressbookList.new }
 
   it 'has an addressbooks attribute' do
     expect(list.addressbook).to be_kind_of(Array)

--- a/spec/netsuite/records/addressbook_spec.rb
+++ b/spec/netsuite/records/addressbook_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+describe NetSuite::Records::Addressbook do
+  # address schema changed in 2014.2. We support < 2014.2 schema, but we don't test support
+
+  before do
+    NetSuite::Configuration.api_version = '2014_2'
+  end
+
+  let(:attributes) do
+    {
+      :addressbook => {
+        :addressbook_address => NetSuite::Records::Address.new({
+                                  :addr1        => '123 Happy Lane',
+                                  :addr_text    => "123 Happy Lane\nLos Angeles CA 90007",
+                                  :city         => 'Los Angeles',
+                                  :country      => '_unitedStates',
+                                  :state        => 'CA',
+                                  :override     => false,
+                                  :zip          => '90007'
+                                    }),
+        :default_billing  => true,
+        :default_shipping => true,
+        :internal_id      => '567',
+        :is_residential   => false,
+        :label            => '123 Happy Lane'
+      }
+    }
+  end
+
+  let(:list) { NetSuite::Records::Addressbook.new(attributes) }
+
+  it 'has all the right fields' do
+    [
+      :default_billing, :default_shipping, :internal_id,
+               :is_residential, :label
+    ].each do |field|
+      expect(list).to have_field(field)
+    end
+
+    expect(list.addressbook_address).to_not be_nil
+  end
+
+  describe '#initialize' do
+    context 'when taking in a hash of attributes' do
+      it 'sets the attributes for the object given the attributes hash' do
+        expect(list.addressbook_address.addr1).to eql('123 Happy Lane')
+        expect(list.addressbook_address.addr_text).to eql("123 Happy Lane\nLos Angeles CA 90007")
+        expect(list.addressbook_address.city).to eql('Los Angeles')
+        expect(list.addressbook_address.country.to_record).to eql('_unitedStates')
+        expect(list.addressbook_address.override).to be_falsey
+        expect(list.addressbook_address.state).to eql('CA')
+        expect(list.addressbook_address.zip).to eql('90007')
+        expect(list.default_billing).to be_truthy
+        expect(list.default_shipping).to be_truthy
+        expect(list.is_residential).to be_falsey
+        expect(list.label).to eql('123 Happy Lane')
+        expect(list.internal_id).to eql('567')
+      end
+    end
+
+    context 'when taking in a AddressbookList instance' do
+      it 'sets the attributes for the object given the record attributes' do
+        old_list = NetSuite::Records::Addressbook.new(attributes)
+        list     = NetSuite::Records::Addressbook.new(old_list)
+        expect(list.addressbook_address.addr1).to eql('123 Happy Lane')
+        expect(list.addressbook_address.addr_text).to eql("123 Happy Lane\nLos Angeles CA 90007")
+        expect(list.addressbook_address.city).to eql('Los Angeles')
+        expect(list.addressbook_address.country.to_record).to eql('_unitedStates')
+        expect(list.addressbook_address.override).to be_falsey
+        expect(list.addressbook_address.state).to eql('CA')
+        expect(list.addressbook_address.zip).to eql('90007')
+        expect(list.default_billing).to be_truthy
+        expect(list.default_shipping).to be_truthy
+        expect(list.is_residential).to be_falsey
+        expect(list.label).to eql('123 Happy Lane')
+        expect(list.internal_id).to eql('567')
+      end
+    end
+  end
+
+  describe '#to_record' do
+    it 'can represent itself as a SOAP record' do
+      record = {
+          'listRel:addressbookAddress' => {
+            'platformCommon:addr1'     => '123 Happy Lane',
+            'platformCommon:city'      => 'Los Angeles',
+            'platformCommon:country'   => '_unitedStates',
+            'platformCommon:override'  => false,
+            'platformCommon:state'     => 'CA',
+            'platformCommon:zip'       => '90007'
+          },
+        'listRel:defaultBilling'  => true,
+        'listRel:defaultShipping' => true,
+        'listRel:isResidential'   => false,
+        'listRel:label'           => '123 Happy Lane',
+        'listRel:internalId'      => '567'
+      }
+      expect(list.to_record).to eql(record)
+    end
+  end
+
+  describe '#record_type' do
+    it 'returns a string of the record SOAP type' do
+      expect(list.record_type).to eql('listRel:Addressbook')
+    end
+  end
+
+end

--- a/spec/netsuite/records/contact_addressbook_spec.rb
+++ b/spec/netsuite/records/contact_addressbook_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe NetSuite::Records::CustomerAddressbook do
+describe NetSuite::Records::ContactAddressbook do
   subject { described_class.new }
 
   describe '#record_type' do
     it 'returns a string of the record SOAP type' do
-      expect(subject.record_type).to eql('listRel:CustomerAddressbook')
+      expect(subject.record_type).to eql('listRel:ContactAddressbook')
     end
   end
 end

--- a/spec/netsuite/records/custom_field_list_spec.rb
+++ b/spec/netsuite/records/custom_field_list_spec.rb
@@ -37,9 +37,10 @@ describe NetSuite::Records::CustomFieldList do
   context 'writing convience methods' do
     it "should create a custom field entry when none exists" do
       list.custrecord_somefield = 'a value'
-      list.custom_fields.size.should == 1
-      list.custom_fields.first.value.should == 'a value'
-      list.custom_fields.first.type.should == 'platformCore:StringCustomFieldRef'
+
+      expect(list.custom_fields.size).to eq(1)
+      expect(list.custom_fields.first.value).to eq('a value')
+      expect(list.custom_fields.first.type).to eq('platformCore:StringCustomFieldRef')
     end
 
     # https://github.com/NetSweet/netsuite/issues/325

--- a/spec/netsuite/records/employee_addressbook_spec.rb
+++ b/spec/netsuite/records/employee_addressbook_spec.rb
@@ -1,11 +1,11 @@
 require 'spec_helper'
 
-describe NetSuite::Records::CustomerAddressbook do
+describe NetSuite::Records::EmployeeAddressbook do
   subject { described_class.new }
 
   describe '#record_type' do
     it 'returns a string of the record SOAP type' do
-      expect(subject.record_type).to eql('listRel:CustomerAddressbook')
+      expect(subject.record_type).to eql('listRel:EmployeeAddressbook')
     end
   end
 end

--- a/spec/netsuite/records/employee_spec.rb
+++ b/spec/netsuite/records/employee_spec.rb
@@ -117,10 +117,25 @@ describe NetSuite::Records::Employee do
   end
 
   describe '#to_record' do
-    let(:employee) { NetSuite::Records::Employee.new(:email => 'bob@example.com') }
+    let(:employee) do
+      emp = NetSuite::Records::Employee.new(:email => 'bob@example.com')
+      emp.custom_field_list.foo = 'bar'
+      emp
+    end
 
     it 'returns a hash of attributes that can be used in a SOAP request' do
-      expect(employee.to_record).to eql({ 'listEmp:email' => 'bob@example.com' })
+      expect(employee.to_record).to eql({
+        'listEmp:customFieldList!' => {
+          'platformCore:customField' => [
+            {
+              'platformCore:value' => 'bar',
+              '@scriptId' => 'foo',
+              '@xsi:type' => 'platformCore:StringCustomFieldRef'
+            }
+          ]
+        },
+        'listEmp:email' => 'bob@example.com'
+      })
     end
   end
 

--- a/spec/netsuite/records/employee_spec.rb
+++ b/spec/netsuite/records/employee_spec.rb
@@ -3,26 +3,14 @@ require 'spec_helper'
 describe NetSuite::Records::Employee do
   let(:employee) { NetSuite::Records::Employee.new }
 
-  it 'has all the right fields' do
-    [
-      :account_number, :alien_number, :approval_limit, :bill_pay, :birth_date,
-      :comments, :date_created, :direct_deposit, :eligible_for_commission,
-      :email, :entity_id, :expense_limit,
-      :fax, :first_name, :hire_date, :home_phone, :is_inactive, :is_job_resource,
-      :job_description, :labor_cost, :last_modified_date, :last_name, :middle_name,
-      :mobile_phone, :next_review_date, :office_phone, :pay_frequency, :phone,
-      :phonetic_name, :purchase_order_approval_limit, :purchase_order_approver,
-      :purchase_order_limit, :release_date, :resident_status, :salutation,
-      :social_security_number, :title, :visa_exp_date, :visa_type
-    ].each do |field|
+  it 'has all the expected fields' do
+    NetSuite::Records::Employee::FIELDS.each do |field|
       expect(employee).to have_field(field)
     end
   end
 
-  it 'has all the right record refs' do
-    [
-      :location, :employee_status, :employee_type
-    ].each do |record_ref|
+  it 'has all the expected record_refs' do
+    NetSuite::Records::Employee::RECORD_REFS.each do |record_ref|
       expect(employee).to have_record_ref(record_ref)
     end
   end
@@ -32,7 +20,7 @@ describe NetSuite::Records::Employee do
     it 'can be set from a RoleList object'
   end
 
-  describe '.get' do
+  describe '#get' do
     context 'when the response is successful' do
       let(:response) { NetSuite::Response.new(:success => true, :body => { :account_number => 7 }) }
 
@@ -106,7 +94,7 @@ describe NetSuite::Records::Employee do
     end
   end
 
-  describe '.update' do
+  describe '#update' do
     context 'when the response is successful' do
       let(:response) { NetSuite::Response.new(:success => true, :body => { :email => 'leland.palmer@example.com' }) }
 
@@ -139,14 +127,6 @@ describe NetSuite::Records::Employee do
   describe '#record_type' do
     it 'returns a string type for the record to be used in a SOAP request' do
       expect(employee.record_type).to eql('listEmp:Employee')
-    end
-  end
-
-  it 'has the right record_refs' do
-    [
-      :currency, :department, :location, :subsidiary
-    ].each do |record_ref|
-      expect(employee).to have_record_ref(record_ref)
     end
   end
 end

--- a/spec/netsuite/records/employee_spec.rb
+++ b/spec/netsuite/records/employee_spec.rb
@@ -4,13 +4,72 @@ describe NetSuite::Records::Employee do
   let(:employee) { NetSuite::Records::Employee.new }
 
   it 'has all the expected fields' do
-    NetSuite::Records::Employee::FIELDS.each do |field|
+    %w{
+      account_number
+      alien_number
+      alt_name
+      approval_limit
+      bill_pay
+      birth_date
+      comments
+      date_created
+      default_address
+      direct_deposit
+      eligible_for_commission
+      email
+      entity_id
+      expense_limit
+      fax
+      first_name
+      gender
+      give_access
+      hire_date
+      home_phone
+      is_inactive
+      is_job_resource
+      is_sales_rep
+      is_support_rep
+      job_description
+      klass
+      labor_cost
+      last_modified_date
+      last_name
+      last_review_date
+      middle_name
+      mobile_phone
+      next_review_date
+      office_phone
+      password
+      password2
+      pay_frequency
+      phone
+      phonetic_name
+      purchase_order_approval_limit
+      purchase_order_approver
+      purchase_order_limit
+      release_date
+      resident_status
+      salutation
+      send_email
+      social_security_number
+      title
+      visa_exp_date
+      visa_type
+    }.map(&:to_sym).each do |field|
       expect(employee).to have_field(field)
     end
   end
 
   it 'has all the expected record_refs' do
-    NetSuite::Records::Employee::RECORD_REFS.each do |record_ref|
+    %w{
+      currency
+      department
+      employee_status
+      employee_type
+      location
+      subsidiary
+      supervisor
+    }.map(&:to_sym).each do |record_ref|
       expect(employee).to have_record_ref(record_ref)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,4 +19,5 @@ Dir['spec/support/**/*.rb'].each { |f| require f }
 RSpec.configure do |config|
   config.mock_framework = :rspec
   config.color = true
+  config.raise_errors_for_deprecations!
 end


### PR DESCRIPTION
My company, Namely, has had a fork of this gem for quite some time:
https://github.com/NetSweet/netsuite/compare/master...namely:master

We added functionality that didn't exist in current gem as of the fork, and upon further inspection, it doesn't exist in the current version. In an effort to move from our fork to the base gem, this PR:  

- Adds `Employee` functionality.
==>  `addressbook_list` added.
 ==> `default_address` and `gender` fields.

- Adds `*Addressbook*` functionality.
==> DRYs out duplicated code.
==> `EmployeeAddressbook` and `EmployeeAdressbookList` added.

- Cleans up [ 🎨 ] code / specs.

I've added descriptions to all my commit messages detailing the changes.

Looking forward to hearing back, thank you! 