### PR TITLE
Fix VERSION constant module

### DIFF
--- a/lib/netsuite/version.rb
+++ b/lib/netsuite/version.rb
@@ -1,3 +1,3 @@
-module Netsuite
+module NetSuite
   VERSION = '0.8.1'
 end

--- a/netsuite.gemspec
+++ b/netsuite.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   gem.name          = 'netsuite'
   gem.require_paths = ['lib']
-  gem.version       = Netsuite::VERSION
+  gem.version       = NetSuite::VERSION
 
   gem.add_dependency 'savon', '>= 2.3.0'
 


### PR DESCRIPTION
It was under `Netsuite` instead of `NetSuite` (capitalization) like
everything else in the gem. With this change there are no remaining references to `Netsuite`.

I noticed this while working on an application that kept its own NetSuite integration code under `Netsuite` to avoid collisions.