### PR TITLE
Support expand_item_group on SalesOrderItem records

### DIFF
--- a/lib/netsuite/records/sales_order_item.rb
+++ b/lib/netsuite/records/sales_order_item.rb
@@ -6,11 +6,18 @@ module NetSuite
       include Support::Records
       include Namespaces::TranSales
 
-      fields :amount, :bin_numbers, :cost_estimate, :cost_estimate_type, :defer_rev_rec, :description, :expand_item_group, :gift_cert_from,
-        :gift_cert_message, :gift_cert_number, :gift_cert_recipient_email, :gift_cert_recipient_name, :gross_amt, :is_taxable,
-        :line, :order_line, :po_currency, :quantity, :rate, :rev_rec_end_date, :rev_rec_start_date, :rev_rec_term_in_months,
-        :serial_numbers, :shipping_cost, :tax1_amt, :tax_rate1, :tax_rate2, :vsoe_allocation, :vsoe_amount, :vsoe_deferral,
-        :vsoe_delivered, :vsoe_permit_discount, :vsoe_price, :is_closed, :quantity_commited, :quantity_fulfilled
+      fields :amount, :bin_numbers, :cost_estimate,
+        :cost_estimate_type, :defer_rev_rec, :description,
+        :expand_item_group, :gift_cert_from, :gift_cert_message,
+        :gift_cert_number, :gift_cert_recipient_email,
+        :gift_cert_recipient_name, :gross_amt, :is_closed,
+        :is_taxable, :line, :order_line, :po_currency, :quantity,
+        :quantity_commited, :quantity_fulfilled, :rate,
+        :rev_rec_end_date, :rev_rec_start_date,
+        :rev_rec_term_in_months, :serial_numbers, :shipping_cost,
+        :tax1_amt, :tax_rate1, :tax_rate2, :vsoe_allocation,
+        :vsoe_amount, :vsoe_deferral, :vsoe_delivered,
+        :vsoe_permit_discount, :vsoe_price
 
       field :custom_field_list, CustomFieldList
 

--- a/lib/netsuite/records/sales_order_item.rb
+++ b/lib/netsuite/records/sales_order_item.rb
@@ -6,7 +6,7 @@ module NetSuite
       include Support::Records
       include Namespaces::TranSales
 
-      fields :amount, :bin_numbers, :cost_estimate, :cost_estimate_type, :defer_rev_rec, :description, :gift_cert_from,
+      fields :amount, :bin_numbers, :cost_estimate, :cost_estimate_type, :defer_rev_rec, :description, :expand_item_group, :gift_cert_from,
         :gift_cert_message, :gift_cert_number, :gift_cert_recipient_email, :gift_cert_recipient_name, :gross_amt, :is_taxable,
         :line, :order_line, :po_currency, :quantity, :rate, :rev_rec_end_date, :rev_rec_start_date, :rev_rec_term_in_months,
         :serial_numbers, :shipping_cost, :tax1_amt, :tax_rate1, :tax_rate2, :vsoe_allocation, :vsoe_amount, :vsoe_deferral,

--- a/spec/netsuite/records/sales_order_item_spec.rb
+++ b/spec/netsuite/records/sales_order_item_spec.rb
@@ -5,11 +5,15 @@ describe NetSuite::Records::SalesOrderItem do
 
   it 'has all the right fields' do
     [
-      :amount, :bin_numbers, :cost_estimate, :cost_estimate_type, :defer_rev_rec, :description, :expand_item_group, :gift_cert_from,
-      :gift_cert_message, :gift_cert_number, :gift_cert_recipient_email, :gift_cert_recipient_name, :gross_amt, :is_taxable,
-      :line, :order_line, :po_currency, :quantity, :rate, :rev_rec_end_date, :rev_rec_start_date, :rev_rec_term_in_months,
-      :serial_numbers, :tax1_amt, :tax_rate1, :tax_rate2, :vsoe_allocation, :vsoe_amount, :vsoe_deferral, :vsoe_delivered,
-      :vsoe_permit_discount, :vsoe_price
+     :amount, :bin_numbers, :cost_estimate, :cost_estimate_type,
+     :defer_rev_rec, :description, :expand_item_group,
+     :gift_cert_from, :gift_cert_message, :gift_cert_number,
+     :gift_cert_recipient_email, :gift_cert_recipient_name,
+     :gross_amt, :is_taxable, :line, :order_line, :po_currency,
+     :quantity, :rate, :rev_rec_end_date, :rev_rec_start_date,
+     :rev_rec_term_in_months, :serial_numbers, :tax1_amt, :tax_rate1,
+     :tax_rate2, :vsoe_allocation, :vsoe_amount, :vsoe_deferral,
+     :vsoe_delivered, :vsoe_permit_discount, :vsoe_price
     ].each do |field|
       expect(item).to have_field(field)
     end

--- a/spec/netsuite/records/sales_order_item_spec.rb
+++ b/spec/netsuite/records/sales_order_item_spec.rb
@@ -5,7 +5,7 @@ describe NetSuite::Records::SalesOrderItem do
 
   it 'has all the right fields' do
     [
-      :amount, :bin_numbers, :cost_estimate, :cost_estimate_type, :defer_rev_rec, :description, :gift_cert_from,
+      :amount, :bin_numbers, :cost_estimate, :cost_estimate_type, :defer_rev_rec, :description, :expand_item_group, :gift_cert_from,
       :gift_cert_message, :gift_cert_number, :gift_cert_recipient_email, :gift_cert_recipient_name, :gross_amt, :is_taxable,
       :line, :order_line, :po_currency, :quantity, :rate, :rev_rec_end_date, :rev_rec_start_date, :rev_rec_term_in_months,
       :serial_numbers, :tax1_amt, :tax_rate1, :tax_rate2, :vsoe_allocation, :vsoe_amount, :vsoe_deferral, :vsoe_delivered,


### PR DESCRIPTION
It's a boolean field, as per [the docs](http://www.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2016_1/schema/other/salesorderitem.html?mode=package).