### PR TITLE
Add missing fields to sales order item

### DIFF
--- a/lib/netsuite/records/sales_order_item.rb
+++ b/lib/netsuite/records/sales_order_item.rb
@@ -12,12 +12,12 @@ module NetSuite
         :gift_cert_number, :gift_cert_recipient_email,
         :gift_cert_recipient_name, :gross_amt, :is_closed,
         :is_taxable, :line, :order_line, :po_currency, :quantity,
-        :quantity_commited, :quantity_fulfilled, :rate,
-        :rev_rec_end_date, :rev_rec_start_date,
-        :rev_rec_term_in_months, :serial_numbers, :shipping_cost,
-        :tax1_amt, :tax_rate1, :tax_rate2, :vsoe_allocation,
-        :vsoe_amount, :vsoe_deferral, :vsoe_delivered,
-        :vsoe_permit_discount, :vsoe_price
+        :quantity_back_ordered, :quantity_billed, :quantity_committed,
+        :quantity_fulfilled, :rate, :rev_rec_end_date,
+        :rev_rec_start_date, :rev_rec_term_in_months, :serial_numbers,
+        :shipping_cost, :tax1_amt, :tax_rate1, :tax_rate2,
+        :vsoe_allocation, :vsoe_amount, :vsoe_deferral,
+        :vsoe_delivered, :vsoe_permit_discount, :vsoe_price
 
       field :custom_field_list, CustomFieldList
 

--- a/spec/netsuite/records/sales_order_item_spec.rb
+++ b/spec/netsuite/records/sales_order_item_spec.rb
@@ -10,7 +10,9 @@ describe NetSuite::Records::SalesOrderItem do
      :gift_cert_from, :gift_cert_message, :gift_cert_number,
      :gift_cert_recipient_email, :gift_cert_recipient_name,
      :gross_amt, :is_taxable, :line, :order_line, :po_currency,
-     :quantity, :rate, :rev_rec_end_date, :rev_rec_start_date,
+     :quantity, :quantity_back_ordered, :quantity_billed,
+     :quantity_committed, :quantity_fulfilled,
+     :rate, :rev_rec_end_date, :rev_rec_start_date,
      :rev_rec_term_in_months, :serial_numbers, :tax1_amt, :tax_rate1,
      :tax_rate2, :vsoe_allocation, :vsoe_amount, :vsoe_deferral,
      :vsoe_delivered, :vsoe_permit_discount, :vsoe_price


### PR DESCRIPTION
The quantity_committed had a typo on sales order item and other quantities were omitted.