### PR TITLE
add search to support case

### DIFF
--- a/lib/netsuite/records/support_case.rb
+++ b/lib/netsuite/records/support_case.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListSupport
 
-      actions :get, :get_list, :add, :delete, :update, :upsert
+      actions :get, :get_list, :add, :delete, :update, :upsert, :search
 
       fields :end_date, :incoming_message, :outgoing_message, :search_solution, :email_form, 
              :internal_only, :title, :case_number, :start_date, :email, :phone, :inbound_email, 


### PR DESCRIPTION
As far as I've been able to test. Adding the search action to the Support Case record works fine with out any further modification needed.