### PR TITLE
Add a SalesOrder search example for "Pending Approval" SO's.

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,26 @@ NetSuite::Records::SalesOrder.search({
   }
 }).results
 
+# Search for SalesOrder records with a "Pending Approval" status using the TransactionStatus enum value.
+# https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2016_2/schema/enum/transactionstatus.html
+
+NetSuite::Records::SalesOrder.search(
+  criteria: {
+    basic: [
+      {
+        field: 'type',
+        operator: 'anyOf',
+        value: ['_salesOrder'],
+      },
+      {
+        field: 'status',
+        operator: 'anyOf',
+        value: ['_salesOrderPendingApproval'],
+      },
+    ],
+  },
+)
+
 NetSuite::Records::ItemFulfillment.search({
   criteria: {
     basic: [


### PR DESCRIPTION
As discussed on Slack -- adding an example for this type of SO search that shows how to use the  `TransactionStatus._salesOrderPendingApproval` value for the `status` field.

More valid values are available in the Schema browser: https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2016_2/schema/enum/transactionstatus.html

I'm not sure about just pasting the Schema browser URL in a comment like that. Perhaps I should just remove that line.