### PR TITLE
Fix Libya's NetSuite country value

### DIFF
--- a/lib/netsuite/support/country.rb
+++ b/lib/netsuite/support/country.rb
@@ -128,7 +128,7 @@ module NetSuite
         'LB' => '_lebanon',
         'LS' => '_lesotho',
         'LR' => '_liberia',
-        'LY' => '_libyanArabJamahiriya',
+        'LY' => '_libya',
         'LI' => '_liechtenstein',
         'LT' => '_lithuania',
         'LU' => '_luxembourg',


### PR DESCRIPTION
Use just `_libya` instead of `_libyanArabJamahiriya`

I discovered that one while syncing a Customer record with an address in Libya.

[Docs](https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/enum/country.html?mode=package) for the enum value.