### PR TITLE
Set external_id on custom_record_ref.rb to allow referencing

### DIFF
--- a/lib/netsuite/records/custom_record_ref.rb
+++ b/lib/netsuite/records/custom_record_ref.rb
@@ -40,6 +40,7 @@ module NetSuite
       def to_record
         rec = super
         rec[:@internalId] = @internal_id if @internal_id
+        rec[:@externalId] = @external_id if @external_id
         rec[:@typeId] = @type_id if @type_id
         rec
       end


### PR DESCRIPTION
`internal_id` worked when using `CustomRecordRef` but if you wanted to reference another record using an `external_id` it did not set the attribute.  The `type_id` would get set but upsert would fail with `reference key null` error.