### PR TITLE
Add record ref for posting period to item_fulfillment

### DIFF
--- a/lib/netsuite/records/item_fulfillment.rb
+++ b/lib/netsuite/records/item_fulfillment.rb
@@ -11,7 +11,7 @@ module NetSuite
 
       fields :tran_date, :tran_id, :shipping_cost, :memo, :ship_company, :ship_attention, :ship_addr1,
         :ship_addr2, :ship_city, :ship_state, :ship_zip, :ship_phone, :ship_is_residential,
-        :ship_status, :last_modified_date, :created_date
+        :ship_status, :last_modified_date, :created_date, :posting_period
 
       read_only_fields :handling_cost
 

--- a/spec/netsuite/records/item_fulfillment_spec.rb
+++ b/spec/netsuite/records/item_fulfillment_spec.rb
@@ -44,6 +44,15 @@ module NetSuite
           end
         end
       end
+
+      it 'has all the right record refs' do
+        [
+          :custom_form, :entity, :created_from, :ship_carrier, :ship_method,
+          :ship_address_list, :klass, :ship_country, :posting_period
+        ].each do |record_ref|
+          expect(subject).to have_record_ref(record_ref)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
With multiple accounting periods open, NetSuite defaults to the earliest period open, rather than the latest.  This allows the posting period to be specified when creating an item_fulfillment.