### PR TITLE
Fix Samoa's NetSuite country value

### DIFF
--- a/lib/netsuite/support/country.rb
+++ b/lib/netsuite/support/country.rb
@@ -247,7 +247,7 @@ module NetSuite
         'VI' => '_virginIslandsUSA',
         'WF' => '_wallisAndFutunaIslands',
         'EH' => '_westernSahara',
-        'WS' => '_westernSamoa',
+        'WS' => '_samoa',
         'YE' => '_yemen',
         'YU' => '_yugoslavia',
         'ZM' => '_zambia',


### PR DESCRIPTION
Use just `_samoa` instead of `_westernSamoa`

Very similar to the problem that #379 solved for Libya.

Linking the [docs](https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/enum/country.html?mode=package) for the enum values for reference.