### PR TITLE
Remove duplicated Serbian country code

### DIFF
--- a/lib/netsuite/support/country.rb
+++ b/lib/netsuite/support/country.rb
@@ -184,7 +184,6 @@ module NetSuite
         'QA' => '_qatar',
         'RE' => '_reunionIsland',
         'RO' => '_romania',
-        'RS' => '_serbia',
         'RU' => '_russianFederation',
         'RW' => '_rwanda',
         'BL' => '_saintBarthelemy',


### PR DESCRIPTION
This might be a little overwhelming to review. I removed this duplicated country code causing a constant override warning:

> `lib/netsuite/support/country.rb:187: warning: key "RS" is duplicated and overwritten on line 198`