### PR TITLE
Use time zone support to avoid offset hacking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,5 @@ gem 'pry-rescue'
 # required for CircleCI to build properly with ruby 1.9.3
 gem 'json', '~> 1.8.3'
 gem 'rack', '~> 1.6.4'
+
+gem 'activesupport', '~> 5.0'

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,4 @@ gem 'pry-rescue'
 gem 'json', '~> 1.8.3'
 gem 'rack', '~> 1.6.4'
 
-gem 'activesupport', '~> 5.0'
+gem 'activesupport', '4.2.10'

--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -1,4 +1,5 @@
 require 'set'
+require 'active_support/all'
 
 require 'savon'
 require 'netsuite/version'

--- a/lib/netsuite/utilities.rb
+++ b/lib/netsuite/utilities.rb
@@ -42,7 +42,7 @@ module NetSuite
         # NOTE force a production WSDL so the sandbox settings are ignored
         #      as of 1/20/18 NS will start using the account ID to determine
         #      if a account is sandbox (123_SB1) as opposed to using a sandbox domain
-        
+
         wsdl: 'https://webservices.netsuite.com/wsdl/v2017_2_0/netsuite.wsdl',
 
         # NOTE don't inherit default namespace settings, it includes the API version
@@ -262,17 +262,9 @@ module NetSuite
     # assumes UTC0 unix timestamp
     def normalize_time_to_netsuite_date(unix_timestamp)
       # convert to date to eliminate hr/min/sec
-      time = Time.at(unix_timestamp).utc.to_date.to_datetime
-
-      offset = 8
-      time = time.new_offset("-08:00")
-
-      if time.to_time.dst?
-        offset = 7
-        time = time.new_offset("-07:00")
-      end
-
-      (time + Rational(offset, 24)).iso8601
+      date = Time.at(unix_timestamp).utc.to_date #.to_datetime
+      Time.zone = 'Pacific Time (US & Canada)'
+      Time.zone.parse(date.to_s).iso8601
     end
 
   end

--- a/lib/netsuite/utilities.rb
+++ b/lib/netsuite/utilities.rb
@@ -262,7 +262,7 @@ module NetSuite
     # assumes UTC0 unix timestamp
     def normalize_time_to_netsuite_date(unix_timestamp)
       # convert to date to eliminate hr/min/sec
-      date = Time.at(unix_timestamp).utc.to_date #.to_datetime
+      date = Time.at(unix_timestamp).utc.to_date
       Time.zone = 'Pacific Time (US & Canada)'
       Time.zone.parse(date.to_s).iso8601
     end

--- a/spec/netsuite/utilities_spec.rb
+++ b/spec/netsuite/utilities_spec.rb
@@ -7,7 +7,7 @@ describe NetSuite::Utilities do
       formatted_date = NetSuite::Utilities.normalize_time_to_netsuite_date(stamp.to_time.to_i)
       expect(formatted_date).to eq('2016-07-27T00:00:00-07:00')
 
-      no_dst_stamp = DateTime.parse('Sun, November 6 2017 00:00:00 -0000')
+      no_dst_stamp = DateTime.parse('Mon, November 6 2017 00:00:00 -0000')
       formatted_date = NetSuite::Utilities.normalize_time_to_netsuite_date(no_dst_stamp.to_time.to_i)
       expect(formatted_date).to eq('2017-11-06T00:00:00-08:00')
     end


### PR DESCRIPTION
I think at some point, Circle may have changed the Time Zone environment variable to UTC (or some zone that doesn't observe daylight savings).

After debugging, I think what was happening was that the utility function [line#270](https://github.com/NetSweet/netsuite/blob/master/lib/netsuite/utilities.rb#L270) was always returning `false` for `.dst?` so the offset was never changed from `-08:00` to `-07:00` (hence the failing test).

To test this theory, if you use a date that is within daylight savings, but is the UTC zone, it returns `false` for `.dst?`.  That same time, but in Pacific Time zone/offset, returns `true`.

And the main catch here is that `.to_time` returns the time in the local time zone, so even though the `.dst?` check in the utility function was after changing the time's offset to Pacific, it always evaluated to `false` because `.to_time` was always changing it back from PST to whatever the local zone is specified for the environment (I imagine UTC), and therefore didn't make the additional offset change (from `-08:00` to `-07:00) to be correct when the provided date was within daylight savings.

Instead of the current approach, manually changing the offset, then adding back the number of hours for the offset, I added active support which adds some time zone helpers, and now we can take the date associated with the provided `unix_timestamp`, use `Time.zone.parse(date)`, and the returned `Time` object will already have the correct offset set based on the date that was parsed.  Not sure how heavy a gem `activesupport` is, but this resolves the time issue, which probably wouldn't have manifested itself in production given how NS handles dates, but it works correctly now and all tests pass again.