### PR TITLE
Add Records::TransactionColumnCustomField

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -262,6 +262,7 @@ module NetSuite
     autoload :Task,                             'netsuite/records/task'
     autoload :Term,                             'netsuite/records/term'
     autoload :TimeBill,                         'netsuite/records/time_bill'
+    autoload :TransactionColumnCustomField,     'netsuite/records/transaction_column_custom_field'
     autoload :TransactionShipGroup,             'netsuite/records/transaction_ship_group'
     autoload :TransferOrder,                    'netsuite/records/transfer_order'
     autoload :TransferOrderItemList,            'netsuite/records/transfer_order_item_list'

--- a/lib/netsuite/records/transaction_column_custom_field.rb
+++ b/lib/netsuite/records/transaction_column_custom_field.rb
@@ -1,0 +1,59 @@
+module NetSuite
+  module Records
+    class TransactionColumnCustomField
+      include Support::Fields
+      include Support::RecordRefs
+      include Support::Records
+      include Support::Actions
+      include Namespaces::SetupCustom
+
+      actions :get, :get_list, :add, :delete, :update, :upsert, :upsert_list
+
+      # http://www.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_1/schema/record/transactioncolumncustomfield.html
+      fields(
+        :label,
+        :store_value,
+        :display_type,
+        :is_mandatory,
+        :default_checked,
+        :is_formula,
+        :col_expense,
+        :col_purchase,
+        :col_sale,
+        :col_opportunity,
+        :col_store,
+        :col_store_hidden,
+        :col_journal,
+        :col_expense_report,
+        :col_time,
+        :col_transfer_order,
+        :col_item_receipt,
+        :col_item_receipt_order,
+        :col_item_fulfillment,
+        :col_item_fulfillment_order,
+        :col_print_flag,
+        :col_picking_ticket,
+        :col_packing_slip,
+        :col_return_form,
+        :col_store_with_groups,
+        :col_group_on_invoices,
+        :col_kit_item,
+        :access_level,
+        :search_level,
+        :field_type,
+        :script_id
+      )
+
+      record_refs :owner
+
+      attr_reader :internal_id
+      attr_accessor :external_id
+
+      def initialize(attributes = {})
+        @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
+        @external_id = attributes.delete(:external_id) || attributes.delete(:@external_id)
+        initialize_from_attributes_hash(attributes)
+      end
+    end
+  end
+end

--- a/spec/netsuite/records/basic_record_spec.rb
+++ b/spec/netsuite/records/basic_record_spec.rb
@@ -59,7 +59,8 @@ describe 'basic records' do
       NetSuite::Records::InterCompanyJournalEntry,
       NetSuite::Records::BinTransfer,
       NetSuite::Records::SerializedAssemblyItem,
-      NetSuite::Records::CustomerStatus
+      NetSuite::Records::CustomerStatus,
+      NetSuite::Records::TransactionColumnCustomField,
     ]
   }
 

--- a/spec/netsuite/records/transaction_column_custom_field_spec.rb
+++ b/spec/netsuite/records/transaction_column_custom_field_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe NetSuite::Records::TransactionColumnCustomField do
+  describe ".get" do
+    context "success" do
+      let(:internal_id) { 1 }
+      let(:response) do
+        NetSuite::Response.new(
+          success: true,
+          body: { 
+            access_level: "_none",
+            field_type: "_decimalNumber",
+            label: "Billing System Tax",
+          }
+        )
+      end
+
+      it "returns a TransactionColumnCustomField instance with populated fields" do
+        expect(NetSuite::Actions::Get)
+          .to receive(:call)
+          .with([NetSuite::Records::TransactionColumnCustomField, internal_id: internal_id], {})
+          .and_return(response)
+
+        record = NetSuite::Records::TransactionColumnCustomField.get(internal_id: internal_id)
+
+        expect(record.access_level).to eql("_none")
+        expect(record.field_type).to eql("_decimalNumber")
+        expect(record.label).to eql("Billing System Tax")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for the SuiteTalk [TransactionColumnCustomField](http://www.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_1/schema/record/transactioncolumncustomfield.html) record.