### PR TITLE
Throw a helpful error when netsuite returns the wrong thing

### DIFF
--- a/lib/netsuite/errors.rb
+++ b/lib/netsuite/errors.rb
@@ -2,6 +2,7 @@ module NetSuite
   class RecordNotFound < StandardError; end
   class InitializationError < StandardError; end
   class ConfigurationError < StandardError; end
+  class InvalidResponseError < StandardError; end
 
   # NOTE not an exception, used as a wrapped around NetSuite SOAP error
   class Error

--- a/lib/netsuite/response.rb
+++ b/lib/netsuite/response.rb
@@ -7,6 +7,8 @@ module NetSuite
       @header   = attributes[:header]
       @body     = attributes[:body]
       @errors   = attributes[:errors] || []
+
+      validate_response
     end
 
     def success!
@@ -15,6 +17,10 @@ module NetSuite
 
     def success?
       @success
+    end
+
+    def validate_response
+      raise NetSuite::InvalidResponseError unless @body.is_a?(Hash)
     end
   end
 end

--- a/lib/netsuite/response.rb
+++ b/lib/netsuite/response.rb
@@ -20,7 +20,7 @@ module NetSuite
     end
 
     def validate_response
-      raise NetSuite::InvalidResponseError unless @body.is_a?(Hash)
+      raise NetSuite::InvalidResponseError unless @body.is_a?(Hash) || @body.is_a?(Array)
     end
   end
 end

--- a/spec/netsuite/response_spec.rb
+++ b/spec/netsuite/response_spec.rb
@@ -1,26 +1,33 @@
 require 'spec_helper'
 
 describe NetSuite::Response do
-  let(:response) { NetSuite::Response.new }
+  let(:response) { NetSuite::Response.new(:body => test_body) }
+  let(:test_body) { { :banana => 'sandwich' } }
 
   describe '#initialize' do
     it 'allows the body to be set through a :body option' do
-      test_body = { :banana => 'sandwich' }
       response  = NetSuite::Response.new(:body => test_body)
       expect(response.body).to eql(test_body)
     end
 
     it 'allows the success status to be set through a :success option' do
-      response = NetSuite::Response.new(:success => true)
+      response = NetSuite::Response.new(:success => true, :body => test_body)
       expect(response).to be_success
+    end
+
+    context 'when a non-SOAP compliant responce is returned' do
+      it 'raises an error' do
+        expect { NetSuite::Response.new(:body => "<div> I'm just a little website. </div>") }
+            .to raise_error(NetSuite::InvalidResponseError)
+      end
     end
   end
 
   describe '#body' do
     it 'returns the hash contents of the SOAP response body' do
-      test_body     = { :test => false }
-      response.body = test_body
-      expect(response.body).to eql(test_body)
+      test_body_2   = { :test => false }
+      response.body = test_body_2
+      expect(response.body).to eql(test_body_2)
     end
   end
 


### PR DESCRIPTION
A few days ago, a Netsuite server went down, and when we tried to fetch data the server returned an error html page. The gem then through an unable to parse JSON error. This blew up our Netsuite integration with errors. These errors are really difficult to handle in their current state because they are just ruby type errors. By throwing a more distinctive error when we get an invalid response, it will make it far easier to handle an invalid Netsuite response.  