### PR TITLE
Add NetSuite::Records::EntityCustomField

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -154,6 +154,7 @@ module NetSuite
     autoload :DiscountItem,                     'netsuite/records/discount_item'
     autoload :Duration,                         'netsuite/records/duration'
     autoload :Employee,                         'netsuite/records/employee'
+    autoload :EntityCustomField,                'netsuite/records/entity_custom_field'
     autoload :File,                             'netsuite/records/file'
     autoload :GiftCertificate,                  'netsuite/records/gift_certificate'
     autoload :GiftCertificateItem,              'netsuite/records/gift_certificate_item'

--- a/lib/netsuite/records/entity_custom_field.rb
+++ b/lib/netsuite/records/entity_custom_field.rb
@@ -1,0 +1,53 @@
+module NetSuite
+  module Records
+    class EntityCustomField
+      include Support::Fields
+      include Support::RecordRefs
+      include Support::Records
+      include Support::Actions
+      include Namespaces::SetupCustom
+
+      actions :get, :get_list, :add, :delete, :update, :upsert, :upsert_list
+
+      # https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_1/schema/record/entitycustomfield.html
+      fields(
+        :access_level,
+        :applies_to_contact,
+        :applies_to_customer,
+        :applies_to_employee,
+        :applies_to_group,
+        :applies_to_other_name,
+        :applies_to_partner,
+        :applies_to_price_list,
+        :applies_to_statement,
+        :applies_to_vendor,
+        :applies_to_web_site,
+        :available_externally,
+        :check_spelling,
+        :default_checked,
+        :display_type,
+        :field_type,
+        :global_search,
+        :is_formula,
+        :is_mandatory,
+        :is_parent,
+        :label,
+        :script_id,
+        :search_level,
+        :show_in_list,
+        :store_value,
+      )
+
+      record_refs :owner
+
+      attr_reader :internal_id
+      attr_accessor :external_id
+
+      def initialize(attributes = {})
+        @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
+        @external_id = attributes.delete(:external_id) || attributes.delete(:@external_id)
+        initialize_from_attributes_hash(attributes)
+      end
+    end
+  end
+end

--- a/spec/netsuite/records/basic_record_spec.rb
+++ b/spec/netsuite/records/basic_record_spec.rb
@@ -61,6 +61,7 @@ describe 'basic records' do
       NetSuite::Records::SerializedAssemblyItem,
       NetSuite::Records::CustomerStatus,
       NetSuite::Records::TransactionColumnCustomField,
+      NetSuite::Records::EntityCustomField,
     ]
   }
 

--- a/spec/netsuite/records/entity_custom_field_spec.rb
+++ b/spec/netsuite/records/entity_custom_field_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+describe NetSuite::Records::EntityCustomField do
+  describe ".get" do
+    context "success" do
+      let(:internal_id) { 1 }
+      let(:response) do
+        NetSuite::Response.new(
+          success: true,
+          body: { 
+            access_level: "_edit",
+            field_type: "_integerNumber",
+            label: "Salesforce Customer ID",
+            show_in_list: true,
+          }
+        )
+      end
+
+      it "returns a EntityCustomField instance with populated fields" do
+        expect(NetSuite::Actions::Get)
+          .to receive(:call)
+          .with([NetSuite::Records::EntityCustomField, internal_id: internal_id], {})
+          .and_return(response)
+
+        record = NetSuite::Records::EntityCustomField.get(internal_id: internal_id)
+
+        expect(record.access_level).to eql("_edit")
+        expect(record.field_type).to eql("_integerNumber")
+        expect(record.label).to eql("Salesforce Customer ID")
+        expect(record.show_in_list).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds support for the [EntityCustomField](https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_1/schema/record/entitycustomfield.html) record.