### PR TITLE
Fix bin number serialization

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -82,6 +82,7 @@ module NetSuite
     autoload :BillingScheduleRecurrence,        'netsuite/records/billing_schedule_recurrence'
     autoload :BillingScheduleRecurrenceList,    'netsuite/records/billing_schedule_recurrence_list'
     autoload :Bin,                              'netsuite/records/bin'
+    autoload :BinNumber,                        'netsuite/records/bin_number'
     autoload :BinNumberList,                    'netsuite/records/bin_number_list'
     autoload :BinTransfer,                      'netsuite/records/bin_transfer'
     autoload :BinTransferInventory,             'netsuite/records/bin_transfer_inventory'

--- a/lib/netsuite/records/bin_number.rb
+++ b/lib/netsuite/records/bin_number.rb
@@ -1,0 +1,18 @@
+module NetSuite
+  module Records
+    class BinNumber
+      include Support::Fields
+      include Support::Records
+      include Support::RecordRefs
+      include Namespaces::ListAcct
+
+      record_ref :bin_number
+
+      fields :preferred_bin, :location
+
+      def initialize(attributes = {})
+        initialize_from_attributes_hash(attributes)
+      end
+    end
+  end
+end

--- a/lib/netsuite/records/bin_number_list.rb
+++ b/lib/netsuite/records/bin_number_list.rb
@@ -1,30 +1,11 @@
 module NetSuite
   module Records
-    # TODO this is fairly messy: shouldn't mix multiple classes in one file
-    # might be possible to trash the GenericField as well
-
-    class GenericField
-      include Support::Attributes
-      include Support::Fields
-
-      def initialize(attributes = {})
-        self.attributes = attributes
-      end
-    end
-
-    class BinNumber < GenericField
-      include Support::Records
-
-    end
-
     class BinNumberList < Support::Sublist
-      include Namespaces::PlatformCore
-      # include Namespaces::ListAcct
+      include Namespaces::ListAcct
 
       sublist :bin_number, BinNumber
 
       alias :bin_numbers :bin_number
-
     end
   end
 end

--- a/spec/netsuite/records/bin_number_spec.rb
+++ b/spec/netsuite/records/bin_number_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe NetSuite::Records::BinNumber do
+  it "has all the right fields" do
+    bin_number = described_class.new
+
+    [:preferred_bin, :location].each do |field|
+      expect(bin_number).to have_field(field)
+    end
+  end
+
+  it "has all the right record refs" do
+    bin_number = described_class.new
+
+    expect(bin_number).to have_record_ref(:bin_number)
+  end
+
+  it "has the right namespace" do
+    bin_number = described_class.new
+
+    expect(bin_number.record_namespace).to eq('listAcct')
+  end
+end


### PR DESCRIPTION
#### What's this PR do?
With this change we'll make sure we're using the right namespace for bin numbers, according to the netsuite schema documentation, both `BinNumberList` and `BinNumber` are defined under the `listAcct` namespace.

We'll also extract the `BinNumber` class into its own file and define the proper fields for it.

#### Notes
My app is using `2017_2` as its API version I'm not 100% sure if these changes are applicable to previous versions, I used the following link for reference: http://www.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_2/schema/other/inventoryitembinnumberlist.html?mode=package