### PR TITLE
Add NetSuite::Records::TransactionBodyCustomField

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -263,6 +263,7 @@ module NetSuite
     autoload :Task,                             'netsuite/records/task'
     autoload :Term,                             'netsuite/records/term'
     autoload :TimeBill,                         'netsuite/records/time_bill'
+    autoload :TransactionBodyCustomField,       'netsuite/records/transaction_body_custom_field'
     autoload :TransactionColumnCustomField,     'netsuite/records/transaction_column_custom_field'
     autoload :TransactionShipGroup,             'netsuite/records/transaction_ship_group'
     autoload :TransferOrder,                    'netsuite/records/transfer_order'

--- a/lib/netsuite/records/transaction_body_custom_field.rb
+++ b/lib/netsuite/records/transaction_body_custom_field.rb
@@ -1,0 +1,61 @@
+module NetSuite
+  module Records
+    class TransactionBodyCustomField
+      include Support::Fields
+      include Support::RecordRefs
+      include Support::Records
+      include Support::Actions
+      include Namespaces::SetupCustom
+
+      actions :get, :get_list, :add, :delete, :update, :upsert, :upsert_list
+
+      # http://www.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_1/schema/record/transactionbodycustomfield.html
+      fields(
+        :label,
+        :store_value,
+        :display_type,
+        :is_mandatory,
+        :default_checked,
+        :is_formula,
+        :body_assembly_build,
+        :body_bom,
+        :body_b_tegata,
+        :body_customer_payment,
+        :body_deposit,
+        :body_expense_report,
+        :body_inventory_adjustment,
+        :body_item_fulfillment,
+        :body_item_fulfillment_order,
+        :body_item__receipt,
+        :body_item__receipt_order,
+        :body_journal,
+        :body_opportunity,
+        :body_other_transaction,
+        :body_picking_ticket,
+        :body_print_flag,
+        :body_print_packing_slip,
+        :body_print_statement,
+        :body_purchase,
+        :body_sale,
+        :body_store,
+        :body_transfer_order,
+        :body_vendor_payment,
+        :access_level,
+        :search_level,
+        :field_type,
+        :script_id
+      )
+
+      record_refs :owner
+
+      attr_reader :internal_id
+      attr_accessor :external_id
+
+      def initialize(attributes = {})
+        @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
+        @external_id = attributes.delete(:external_id) || attributes.delete(:@external_id)
+        initialize_from_attributes_hash(attributes)
+      end
+    end
+  end
+end

--- a/spec/netsuite/records/basic_record_spec.rb
+++ b/spec/netsuite/records/basic_record_spec.rb
@@ -60,8 +60,9 @@ describe 'basic records' do
       NetSuite::Records::BinTransfer,
       NetSuite::Records::SerializedAssemblyItem,
       NetSuite::Records::CustomerStatus,
+      NetSuite::Records::TransactionBodyCustomField,
       NetSuite::Records::TransactionColumnCustomField,
-      NetSuite::Records::EntityCustomField,
+      NetSuite::Records::EntityCustomField
     ]
   }
 

--- a/spec/netsuite/records/transaction_body_custom_field_spec.rb
+++ b/spec/netsuite/records/transaction_body_custom_field_spec.rb
@@ -1,0 +1,32 @@
+require "spec_helper"
+
+describe NetSuite::Records::TransactionBodyCustomField do
+  describe ".get" do
+    context "success" do
+      let(:internal_id) { 1 }
+      let(:response) do
+        NetSuite::Response.new(
+          success: true,
+          body: {
+            access_level: "_edit",
+            field_type: "_freeFormText",
+            label: "Billing System Subdomain",
+          }
+        )
+      end
+
+      it "returns a TransactionColumnCustomField instance with populated fields" do
+        expect(NetSuite::Actions::Get)
+          .to receive(:call)
+          .with([NetSuite::Records::TransactionBodyCustomField, internal_id: internal_id], {})
+          .and_return(response)
+
+        record = NetSuite::Records::TransactionBodyCustomField.get(internal_id: internal_id)
+
+        expect(record.access_level).to eql("_edit")
+        expect(record.field_type).to eql("_freeFormText")
+        expect(record.label).to eql("Billing System Subdomain")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds support for [TransactionBodyCustomField](https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2017_1/schema/record/transactionbodycustomfield.html) record.