### PR TITLE
Do not overwrite 'external_id' attr in update

### DIFF
--- a/lib/netsuite/actions/update.rb
+++ b/lib/netsuite/actions/update.rb
@@ -71,8 +71,12 @@ module NetSuite
 
       module Support
         def update(options = {}, credentials={})
-          options.merge!(:internal_id => internal_id) if respond_to?(:internal_id) && internal_id
-          options.merge!(:external_id => external_id) if respond_to?(:external_id) && external_id
+          options[:internal_id] = internal_id if respond_to?(:internal_id) && internal_id
+
+          if !options.include?(:external_id) || (respond_to?(:external_id) && external_id)
+            options[:external_id] = external_id
+          end
+
           response = NetSuite::Actions::Update.call([self.class, options], credentials)
           @errors = response.errors
           response.success?


### PR DESCRIPTION
Correct me if I am wrong, but I think that `#update` method shouldn't overwrite `external_id` if it is provided in `options`.
Currently, if we want to update `external_id` we have to do something like that:
```
customer.external_id = new_external_id # <= I do not think this should be needed
customer.update(attributes)
```
even when we have `externa_id` set in `attributes` because of [this line](https://github.com/NetSweet/netsuite/blob/70ab07710387ce32f746a6213ec1087a0f764ae7/lib/netsuite/actions/update.rb#L75).

This PR changes that, so update method will correctly update `external_id` if it is provided in attributes. Additionally I changed `#merge!` calls to `#[]=` since it is faster and should be preferred in my opinion ([rubocop rule](https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Performance/RedundantMerge), [performance tests](https://github.com/JuanitoFatas/fast-ruby#hashmerge-vs-hash-code))

([Netsuite docs](https://system.netsuite.com/app/help/helpcenter.nl?fid=section_n3433806.html) say that you should be able to update `external_id`)