### PR TITLE
Attempting to fix an issue when parsing custom fields in search results

### DIFF
--- a/lib/netsuite/actions/update.rb
+++ b/lib/netsuite/actions/update.rb
@@ -71,8 +71,12 @@ module NetSuite
 
       module Support
         def update(options = {}, credentials={})
-          options.merge!(:internal_id => internal_id) if respond_to?(:internal_id) && internal_id
-          options.merge!(:external_id => external_id) if respond_to?(:external_id) && external_id
+          options[:internal_id] = internal_id if respond_to?(:internal_id) && internal_id
+
+          if !options.include?(:external_id) || (respond_to?(:external_id) && external_id)
+            options[:external_id] = external_id
+          end
+
           response = NetSuite::Actions::Update.call([self.class, options], credentials)
           @errors = response.errors
           response.success?

--- a/lib/netsuite/records/custom_field_list.rb
+++ b/lib/netsuite/records/custom_field_list.rb
@@ -110,7 +110,7 @@ module NetSuite
             attrs = custom_field_data.clone
             type = (custom_field_data[:"@xsi:type"] || custom_field_data[:type])
 
-            if type == "platformCore:SelectCustomFieldRef"
+            if type == "platformCore:SelectCustomFieldRef" || custom_field_data[:value].is_a?(Hash)
               attrs[:value] = CustomRecordRef.new(custom_field_data[:value])
             elsif type == 'platformCore:MultiSelectCustomFieldRef'
               attrs[:value] = custom_field_data[:value].map do |entry|


### PR DESCRIPTION
I was getting something like this in my search results:
```
            <setupCustom:customFieldList>
              <platformCore:customField internalId="1171" scriptId="custrecord_188_cseg_division" xsi:type="platformCore:SelectCustomFieldRef">
                <platformCore:value internalId="1" typeId="189">
                  <platformCore:name>Division Name</platformCore:name>
                </platformCore:value>
              </platformCore:customField>
              <platformCore:customField internalId="1168" scriptId="custrecord_cseg_projectid_n117" xsi:type="platformCore:MultiSelectCustomFieldRef">
                <platformCore:value internalId="3" typeId="-117">
                  <platformCore:name>Subsidiary Name</platformCore:name>
                </platformCore:value>
              </platformCore:customField>
            </setupCustom:customFieldList>
```

The second custom field (with type `platformCore:MultiSelectCustomFieldRef`) was being processed as an `Array`, but it was parsed into a `Hash`.  This caused the field value to be inaccessible.

I'm not sure if this is the best way to handle this situation, but figured I'd present this solution and see where it leads.