### PR TITLE
Action `get_all` return errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 vendor/
+/.idea

--- a/spec/netsuite/actions/get_all_spec.rb
+++ b/spec/netsuite/actions/get_all_spec.rb
@@ -7,6 +7,8 @@ describe NetSuite::Actions::GetAll do
   describe 'Currency' do
     context 'retrieving all' do
       let(:message) { { record: [ { record_type: "currency" } ] } }
+      let(:currency) { NetSuite::Records::Currency }
+      let(:response) { currency.get_all({}) }
 
       context 'when successful' do
         before do
@@ -23,12 +25,18 @@ describe NetSuite::Actions::GetAll do
           response = NetSuite::Actions::GetAll.call([NetSuite::Records::Currency])
           expect(response).to be_kind_of(NetSuite::Response)
         end
+
+        it 'returns valid currency list' do
+          expect(response).to be_kind_of(Array)
+          expect(response.count).to eq(5)
+
+          usd = response.first
+          expect(usd).to be_kind_of(NetSuite::Records::Currency)
+          expect(usd.attributes[:name]).to eq('US Dollar')
+        end
       end
 
       context 'when insufficient permissions' do
-        let(:currency) { NetSuite::Records::Currency }
-        let(:response) { currency.get_all({}) }
-
         before do
           savon.expects(:get_all).with(message: message).returns(
             File.read('spec/support/fixtures/get_all/get_all_insufficient_permissions.xml')

--- a/spec/netsuite/actions/get_all_spec.rb
+++ b/spec/netsuite/actions/get_all_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe NetSuite::Actions::GetAll do
+  before(:all) { savon.mock!  }
+  after(:all) { savon.unmock! }
+
+  describe 'Currency' do
+    context 'retrieving all' do
+      let(:message) { { record: [ { record_type: "currency" } ] } }
+
+      context 'when successful' do
+        before do
+          savon.expects(:get_all).with(message: message).returns(
+            File.read('spec/support/fixtures/get_all/get_all_currencies.xml')
+          )
+        end
+
+        it 'makes a valid request to the NetSuite API' do
+          NetSuite::Actions::GetAll.call([NetSuite::Records::Currency])
+        end
+
+        it 'returns a valid Response object' do
+          response = NetSuite::Actions::GetAll.call([NetSuite::Records::Currency])
+          expect(response).to be_kind_of(NetSuite::Response)
+        end
+      end
+
+      context 'when insufficient permissions' do
+        let(:currency) { NetSuite::Records::Currency }
+        let(:response) { currency.get_all({}) }
+
+        before do
+          savon.expects(:get_all).with(message: message).returns(
+            File.read('spec/support/fixtures/get_all/get_all_insufficient_permissions.xml')
+          )
+        end
+
+        it 'provides an error method on the object with details about the error' do
+          response
+          error = currency.errors.first
+
+          expect(error).to be_kind_of(NetSuite::Error)
+          expect(error.type).to eq('ERROR')
+          expect(error.code).to eq('INSUFFICIENT_PERMISSION')
+          expect(error.message).to eq(
+            "Permission Violation: You need  the 'Lists -> Currency' permission to access this page. Please contact your account administrator."
+          )
+        end
+
+        it 'provides an error method on the response' do
+          response
+
+          expect(currency.errors.first).to be_kind_of(NetSuite::Error)
+          expect(response).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/fixtures/get_all/get_all_currencies.xml
+++ b/spec/support/fixtures/get_all/get_all_currencies.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Header>
+    <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2018_1.platform.webservices.netsuite.com">
+      <platformMsgs:nsId>WEBSERVICES_TSTDRV1115270_010420194222336661788757021_365d42</platformMsgs:nsId>
+    </platformMsgs:documentInfo>
+  </soapenv:Header>
+  <soapenv:Body>
+    <getAllResponse xmlns="urn:messages_2018_1.platform.webservices.netsuite.com">
+      <platformCore:getAllResult xmlns:platformCore="urn:core_2018_1.platform.webservices.netsuite.com">
+        <platformCore:status isSuccess="true"/>
+        <platformCore:totalRecords>5</platformCore:totalRecords>
+        <platformCore:recordList>
+          <platformCore:record xmlns:listAcct="urn:accounting_2018_1.lists.webservices.netsuite.com" internalId="1" xsi:type="listAcct:Currency">
+            <listAcct:name>US Dollar</listAcct:name>
+            <listAcct:symbol>USD</listAcct:symbol>
+            <listAcct:isBaseCurrency>true</listAcct:isBaseCurrency>
+            <listAcct:isInactive>false</listAcct:isInactive>
+            <listAcct:overrideCurrencyFormat>false</listAcct:overrideCurrencyFormat>
+            <listAcct:displaySymbol>$</listAcct:displaySymbol>
+            <listAcct:symbolPlacement>_beforeNumber</listAcct:symbolPlacement>
+            <listAcct:locale>_unitedStatesEnglish</listAcct:locale>
+            <listAcct:formatSample>$1,234.56</listAcct:formatSample>
+            <listAcct:exchangeRate>1.0</listAcct:exchangeRate>
+            <listAcct:currencyPrecision>_two</listAcct:currencyPrecision>
+          </platformCore:record>
+          <platformCore:record xmlns:listAcct="urn:accounting_2018_1.lists.webservices.netsuite.com" internalId="2" xsi:type="listAcct:Currency">
+            <listAcct:name>British pound</listAcct:name>
+            <listAcct:symbol>GBP</listAcct:symbol>
+            <listAcct:isBaseCurrency>false</listAcct:isBaseCurrency>
+            <listAcct:isInactive>false</listAcct:isInactive>
+            <listAcct:overrideCurrencyFormat>false</listAcct:overrideCurrencyFormat>
+            <listAcct:displaySymbol>£</listAcct:displaySymbol>
+            <listAcct:symbolPlacement>_beforeNumber</listAcct:symbolPlacement>
+            <listAcct:locale>_unitedKingdomEnglish</listAcct:locale>
+            <listAcct:formatSample>£1,234.56</listAcct:formatSample>
+            <listAcct:exchangeRate>2.365</listAcct:exchangeRate>
+            <listAcct:currencyPrecision>_two</listAcct:currencyPrecision>
+          </platformCore:record>
+          <platformCore:record xmlns:listAcct="urn:accounting_2018_1.lists.webservices.netsuite.com" internalId="3" xsi:type="listAcct:Currency">
+            <listAcct:name>Canadian Dollar</listAcct:name>
+            <listAcct:symbol>CAD</listAcct:symbol>
+            <listAcct:isBaseCurrency>false</listAcct:isBaseCurrency>
+            <listAcct:isInactive>false</listAcct:isInactive>
+            <listAcct:overrideCurrencyFormat>false</listAcct:overrideCurrencyFormat>
+            <listAcct:displaySymbol>$</listAcct:displaySymbol>
+            <listAcct:symbolPlacement>_beforeNumber</listAcct:symbolPlacement>
+            <listAcct:locale>_canadaEnglish</listAcct:locale>
+            <listAcct:formatSample>$1,234.56</listAcct:formatSample>
+            <listAcct:exchangeRate>1.559</listAcct:exchangeRate>
+            <listAcct:currencyPrecision>_two</listAcct:currencyPrecision>
+          </platformCore:record>
+          <platformCore:record xmlns:listAcct="urn:accounting_2018_1.lists.webservices.netsuite.com" internalId="4" xsi:type="listAcct:Currency">
+            <listAcct:name>Euro</listAcct:name>
+            <listAcct:symbol>EUR</listAcct:symbol>
+            <listAcct:isBaseCurrency>false</listAcct:isBaseCurrency>
+            <listAcct:isInactive>false</listAcct:isInactive>
+            <listAcct:overrideCurrencyFormat>false</listAcct:overrideCurrencyFormat>
+            <listAcct:displaySymbol>€</listAcct:displaySymbol>
+            <listAcct:symbolPlacement>_beforeNumber</listAcct:symbolPlacement>
+            <listAcct:locale>_franceFrenchEuro</listAcct:locale>
+            <listAcct:formatSample>€1 234,56</listAcct:formatSample>
+            <listAcct:exchangeRate>1.509</listAcct:exchangeRate>
+            <listAcct:currencyPrecision>_two</listAcct:currencyPrecision>
+          </platformCore:record>
+          <platformCore:record xmlns:listAcct="urn:accounting_2018_1.lists.webservices.netsuite.com" internalId="5" xsi:type="listAcct:Currency">
+            <listAcct:name>Polish Zloty</listAcct:name>
+            <listAcct:symbol>PLN</listAcct:symbol>
+            <listAcct:isBaseCurrency>true</listAcct:isBaseCurrency>
+            <listAcct:isInactive>false</listAcct:isInactive>
+            <listAcct:overrideCurrencyFormat>false</listAcct:overrideCurrencyFormat>
+            <listAcct:displaySymbol>zł</listAcct:displaySymbol>
+            <listAcct:symbolPlacement>_beforeNumber</listAcct:symbolPlacement>
+            <listAcct:locale>_polandPolish</listAcct:locale>
+            <listAcct:formatSample>zł1 234,56</listAcct:formatSample>
+            <listAcct:exchangeRate>0.27</listAcct:exchangeRate>
+            <listAcct:currencyPrecision>_two</listAcct:currencyPrecision>
+          </platformCore:record>
+        </platformCore:recordList>
+      </platformCore:getAllResult>
+    </getAllResponse>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/spec/support/fixtures/get_all/get_all_insufficient_permissions.xml
+++ b/spec/support/fixtures/get_all/get_all_insufficient_permissions.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Header>
+    <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2018_1.platform.webservices.netsuite.com">
+      <platformMsgs:nsId>WEBSERVICES_TSTDRV1115270_01042019421775958535724851_3779906</platformMsgs:nsId>
+    </platformMsgs:documentInfo>
+  </soapenv:Header>
+  <soapenv:Body>
+    <getAllResponse xmlns="urn:messages_2018_1.platform.webservices.netsuite.com">
+      <platformCore:getAllResult xmlns:platformCore="urn:core_2018_1.platform.webservices.netsuite.com">
+        <platformCore:status isSuccess="false">
+          <platformCore:statusDetail type="ERROR">
+            <platformCore:code>INSUFFICIENT_PERMISSION</platformCore:code>
+            <platformCore:message>Permission Violation: You need  the 'Lists -&gt; Currency' permission to access this page. Please contact your account administrator.</platformCore:message>
+          </platformCore:statusDetail>
+        </platformCore:status>
+        <platformCore:totalRecords>5</platformCore:totalRecords>
+      </platformCore:getAllResult>
+    </getAllResponse>
+  </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
Add ability to return errors from `get_all` command.

To preserve compatibility with current approach errors are added to the class method.
```
[3] pry(main)> currency = NetSuite::Records::Currency
=> NetSuite::Records::Currency < Object
[5] pry(main)> currencies = currency.get_all(insufficient_perms.netsuite_credentials)
...
</soapenv:Envelope>

=> false
[6] pry(main)> currency.errors
=> [
    [0] #<NetSuite::Error:0x00007fd66e821d28 @type="ERROR", @code="INSUFFICIENT_PERMISSION", @message="Permission Violation: You need  the 'Lists -> Currency' permission to access this page. Please contact your account administrator.">
]
[7] pry(main)> currencies
=> false
```

My first approach was to return `NetSuite::Response` object which would look like this:
```
=> #<NetSuite::Response:0x00007f8d960c8548 @success=false, @header=nil, @body=nil, @errors=[#<NetSuite::Error:0x00007f8d960c8598 @type="ERROR", @code="INSUFFICIENT_PERMISSION", @message="Permission Violation: You need  the 'Lists -> Currency' permission to access this page. Please contact your account administrator.">]>
```
