### PR TITLE
Add application_id to soap_header if passed in login credentials

### DIFF
--- a/lib/netsuite/actions/login.rb
+++ b/lib/netsuite/actions/login.rb
@@ -28,6 +28,14 @@ module NetSuite
       # </platformCore:wsRoleList>
 
       def self.call(credentials)
+
+        soap_header = {}
+        if credentials[:application_id].present?
+          soap_header = NetSuite::Configuration.soap_header.dup
+          soap_header['platformMsgs:ApplicationInfo'] ||= {}
+          soap_header['platformMsgs:ApplicationInfo']['platformMsgs:applicationId'] = credentials[:application_id]
+        end
+
         passport = NetSuite::Configuration.auth_header.dup
 
 
@@ -39,13 +47,13 @@ module NetSuite
         if passport['platformMsgs:tokenPassport']
           passport['platformMsgs:passport']['platformCore:account'] ||= passport['platformMsgs:tokenPassport']['platformCore:account']
         end
-        
+
         passport['platformMsgs:passport']['platformCore:account'] = credentials[:account] if !credentials[:account].nil?
 
         passport.delete('platformMsgs:tokenPassport')
 
         begin
-          response = NetSuite::Configuration.connection(soap_header: {}).call :login, message: passport
+          response = NetSuite::Configuration.connection(soap_header: soap_header).call :login, message: passport
         rescue Savon::SOAPFault => e
           error_details = e.to_hash[:fault]
 


### PR DESCRIPTION
Application ID needed for login call using 2015.2 endpoint.  Not sure if this is widespread, most people probably don't use this action.  But this will add the `application_id` if it's passed in the credentials hash.

```
D, [2019-04-17T20:00:54.845169 #9369] DEBUG -- : HTTPI /peer GET request to [ACCOUNT_ID]-sb1.suitetalk.api.netsuite.com (net_http)
I, [2019-04-17T20:00:55.301247 #9369]  INFO -- : SOAP request: https://webservices.netsuite.com/services/NetSuitePort_2015_2
I, [2019-04-17T20:00:55.302039 #9369]  INFO -- : SOAPAction: "login", Content-Type: text/xml;charset=UTF-8, Content-Length: 2035
D, [2019-04-17T20:00:55.303663 #9369] DEBUG -- : <?xml version="1.0" encoding="UTF-8"?>
<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:platformMsgs="urn:messages_2015_2.platform.webservices.netsuite.com" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:platformCore="urn:core_2015_2.platform.webservices.netsuite.com" xmlns:platformCommon="urn:common_2015_2.platform.webservices.netsuite.com" xmlns:listRel="urn:relationships_2015_2.lists.webservices.netsuite.com" xmlns:tranSales="urn:sales_2015_2.transactions.webservices.netsuite.com" xmlns:tranPurch="urn:purchases_2015_2.transactions.webservices.netsuite.com" xmlns:actSched="urn:scheduling_2015_2.activities.webservices.netsuite.com" xmlns:setupCustom="urn:customization_2015_2.setup.webservices.netsuite.com" xmlns:listAcct="urn:accounting_2015_2.lists.webservices.netsuite.com" xmlns:tranBank="urn:bank_2015_2.transactions.webservices.netsuite.com" xmlns:tranCust="urn:customers_2015_2.transactions.webservices.netsuite.com" xmlns:tranEmp="urn:employees_2015_2.transactions.webservices.netsuite.com" xmlns:tranInvt="urn:inventory_2015_2.transactions.webservices.netsuite.com" xmlns:listSupport="urn:support_2015_2.lists.webservices.netsuite.com" xmlns:tranGeneral="urn:general_2015_2.transactions.webservices.netsuite.com" xmlns:commGeneral="urn:communication_2015_2.general.webservices.netsuite.com" xmlns:listMkt="urn:marketing_2015_2.lists.webservices.netsuite.com" xmlns:listWebsite="urn:website_2015_2.lists.webservices.netsuite.com" xmlns:fileCabinet="urn:filecabinet_2015_2.documents.webservices.netsuite.com" xmlns:listEmp="urn:employees_2015_2.lists.webservices.netsuite.com">
  <env:Body>
    <platformMsgs:login>
      <platformMsgs:passport>
        <platformCore:email>[EMAIL]</platformCore:email>
        <platformCore:password>[PASSWORD]</platformCore:password>
        <platformCore:role>[ROLE_ID]</platformCore:role>
        <platformCore:account>[ACCOUNT_ID]</platformCore:account>
      </platformMsgs:passport>
    </platformMsgs:login>
  </env:Body>
</env:Envelope>

D, [2019-04-17T20:00:55.306195 #9369] DEBUG -- : HTTPI /peer POST request to webservices.netsuite.com (net_http)
I, [2019-04-17T20:00:56.525502 #9369]  INFO -- : SOAP response (status 500)
D, [2019-04-17T20:00:56.527572 #9369] DEBUG -- : <?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <soapenv:Body>
    <soapenv:Fault>
      <faultcode>soapenv:Server.userException</faultcode>
      <faultstring>Application ID mandatory but missing</faultstring>
      <detail>
        <platformFaults:invalidCredentialsFault xmlns:platformFaults="urn:faults_2015_2.platform.webservices.netsuite.com">
          <platformFaults:code>USER_ERROR</platformFaults:code>
          <platformFaults:message>Application ID mandatory but missing</platformFaults:message>
        </platformFaults:invalidCredentialsFault>
        <ns1:hostname xmlns:ns1="http://xml.apache.org/axis/">partners026.prod.svale.netledger.com</ns1:hostname>
      </detail>
    </soapenv:Fault>
  </soapenv:Body>
</soapenv:Envelope>
```