### PR TITLE
Fix issue with empty `record_list` node in search result

### DIFF
--- a/lib/netsuite/support/search_result.rb
+++ b/lib/netsuite/support/search_result.rb
@@ -29,8 +29,19 @@ module NetSuite
         if @total_records > 0
           if response.body.has_key?(:record_list)
             # basic search results
-            record_list = response.body[:record_list][:record]
-            record_list = [record_list] unless record_list.is_a?(Array)
+
+            #  `recordList` node can contain several nested `record` nodes, only one node or be empty
+            #  so we have to handle all these cases:
+            #    * { record_list: nil }
+            #    * { record_list: { record: => {...} } }
+            #    * { record_list: { record: => [{...}, {...}, ...] } }
+            record_list = if response.body[:record_list].nil?
+              []
+            elsif response.body[:record_list][:record].is_a?(Array)
+              response.body[:record_list][:record]
+            else
+              [response.body[:record_list][:record]]
+            end
 
             record_list.each do |record|
               results << result_class.new(record)

--- a/spec/netsuite/support/search_result_spec.rb
+++ b/spec/netsuite/support/search_result_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe NetSuite::Support::SearchResult do
+  describe '#results' do
+    context 'empty page' do
+      it 'returns empty array' do
+        response_body = {
+          :status => {:@is_success=>"true"},
+          :total_records => "242258",
+          :page_size => "10",
+          :total_pages => "24226",
+          :page_index => "99",
+          :search_id => "WEBSERVICES_4132604_SB1_051620191060155623420663266_336cbf12",
+          :record_list => nil,
+          :"@xmlns:platform_core" => "urn:core_2016_2.platform.webservices.netsuite.com"
+        }
+        response = NetSuite::Response.new(body: response_body)
+
+        results = described_class.new(response, NetSuite::Actions::Search, {}).results
+        expect(results).to eq []
+      end
+    end
+  end
+end


### PR DESCRIPTION
`searchMoreWithId` operation is used for obtaining paged search results. But there is a case when it returns an empty "page" and it leads to an exception:

```
Traceback (most recent call last):
       12: from script/rails:6:in `<main>'
       11: from script/rails:6:in `require'
       10: from /var/www/sites/shiphawk/shared/bundle/ruby/2.5.0/gems/railties-4.2.11.1/lib/rails/commands.rb:17:in `<top (required)>'
        9: from /var/www/sites/shiphawk/shared/bundle/ruby/2.5.0/gems/railties-4.2.11.1/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
        8: from /var/www/sites/shiphawk/shared/bundle/ruby/2.5.0/gems/railties-4.2.11.1/lib/rails/commands/commands_tasks.rb:68:in `console'
        7: from /var/www/sites/shiphawk/shared/bundle/ruby/2.5.0/gems/railties-4.2.11.1/lib/rails/commands/console.rb:9:in `start'
        6: from /var/www/sites/shiphawk/shared/bundle/ruby/2.5.0/gems/railties-4.2.11.1/lib/rails/commands/console.rb:110:in `start'
        5: from (irb):59
        4: from /var/www/sites/shiphawk/releases/20190508170452/app/services/integrations/net_suite/client.rb:236:in `search_more_products'
        3: from /var/www/sites/shiphawk/shared/bundle/ruby/2.5.0/gems/netsuite-0.8.2/lib/netsuite/actions/search.rb:250:in `search'
        2: from /var/www/sites/shiphawk/shared/bundle/ruby/2.5.0/gems/netsuite-0.8.2/lib/netsuite/actions/search.rb:250:in `new'
        1: from /var/www/sites/shiphawk/shared/bundle/ruby/2.5.0/gems/netsuite-0.8.2/lib/netsuite/support/search_result.rb:31:in `initialize'
NoMethodError (undefined method `[]' for nil:NilClass)

```

Example of response:

```xml
<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <soapenv:Header>
    <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2016_2.platform.webservices.netsuite.com">
      <platformMsgs:nsId>WEBSERVICES_4132604_SB1_0514201912300678231364328877_f4767cc</platformMsgs:nsId>
    </platformMsgs:documentInfo>
  </soapenv:Header>
  <soapenv:Body>
    <searchMoreWithIdResponse xmlns="urn:messages_2016_2.platform.webservices.netsuite.com">
      <platformCore:searchResult xmlns:platformCore="urn:core_2016_2.platform.webservices.netsuite.com">
        <platformCore:status isSuccess="true"/>
        <platformCore:totalRecords>98852</platformCore:totalRecords>
        <platformCore:pageSize>10</platformCore:pageSize>
        <platformCore:totalPages>9886</platformCore:totalPages>
        <platformCore:pageIndex>66</platformCore:pageIndex>
        <platformCore:searchId>WEBSERVICES_4132604_SB1_051320191338647791651415611_edb33c93</platformCore:searchId>
        <platformCore:recordList/>
      </platformCore:searchResult>
    </searchMoreWithIdResponse>
  </soapenv:Body>
</soapenv:Envelope>
```

Here this behavior is fixed and empty array will be returned.