### PR TITLE
Add direct_revenue_posting field to non-inventory sale item model

### DIFF
--- a/lib/netsuite/records/non_inventory_sale_item.rb
+++ b/lib/netsuite/records/non_inventory_sale_item.rb
@@ -10,7 +10,7 @@ module NetSuite
       actions :get, :get_list, :add, :delete, :search, :update, :upsert
 
       fields :available_to_partners, :cost_estimate, :cost_estimate_type, :cost_estimate_units, :country_of_manufacture,
-        :created_date, :display_name, :dont_show_price, :enforce_min_qty_internally, :exclude_from_sitemap,
+        :created_date, :direct_revenue_posting, :display_name, :dont_show_price, :enforce_min_qty_internally, :exclude_from_sitemap,
         :featured_description, :handling_cost, :handling_cost_units, :include_children, :is_donation_item, :is_fulfillable,
         :is_gco_compliant, :is_inactive, :is_online, :is_taxable, :item_id, :last_modified_date, :manufacturer,
         :manufacturer_addr1, :manufacturer_city, :manufacturer_state, :manufacturer_tariff, :manufacturer_tax_id,

--- a/spec/netsuite/records/non_inventory_sale_item_spec.rb
+++ b/spec/netsuite/records/non_inventory_sale_item_spec.rb
@@ -6,7 +6,7 @@ describe NetSuite::Records::NonInventorySaleItem do
   it 'has the right fields' do
     [
       :available_to_partners, :cost_estimate, :cost_estimate_type, :cost_estimate_units, :country_of_manufacture, :created_date,
-      :display_name, :dont_show_price, :enforce_min_qty_internally, :exclude_from_sitemap,
+      :direct_revenue_posting, :display_name, :dont_show_price, :enforce_min_qty_internally, :exclude_from_sitemap,
       :featured_description, :handling_cost, :handling_cost_units, :include_children, :is_donation_item, :is_fulfillable,
       :is_gco_compliant, :is_inactive, :is_online, :is_taxable, :item_id, :last_modified_date, :manufacturer, :manufacturer_addr1,
       :manufacturer_city, :manufacturer_state, :manufacturer_tariff, :manufacturer_tax_id, :manufacturer_zip, :matrix_option_list,


### PR DESCRIPTION
Direct revenue posting is a boolean for non-inventory sale item that you can find here http://www.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2018_2/schema/record/noninventorysaleitem.html