### PR TITLE
Update data center url method name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ NetSuite.configure do
   password 'password'
   role 10
 
-  # use `NetSuite::Utilities.netsuite_data_center_urls('TSTDRV1576318')` to retrieve the URL
+  # use `NetSuite::Utilities.data_center_url('TSTDRV1576318')` to retrieve the URL
   # you'll want to do this in a background proces and strip the protocol out of the return string
   wsdl_domain 'tstdrv1576318.suitetalk.api.netsuite.com'
 end


### PR DESCRIPTION
The method name in the README for getting the data center URL seems to be incorrect. This should update it to the working method name with the results of the before and after commands shown below:

```
NetSuite::Utilities.netsuite_data_center_urls('TSTDRV1576318')
NoMethodError: undefined method `netsuite_data_center_urls' for NetSuite::Utilities:Module
```

```
NetSuite::Utilities.data_center_url('TSTDRV1576318')
=> "https://tstdrv1576318.suitetalk.api.netsuite.com"
```

Seems like this might be looked at because of an rspec screenshot: 
![image](https://user-images.githubusercontent.com/3905259/64828180-60a85a00-d595-11e9-9dda-c5926c33ef22.png)
