### PR TITLE
Add the status field to ItemFulfillments

### DIFF
--- a/lib/netsuite/records/item_fulfillment.rb
+++ b/lib/netsuite/records/item_fulfillment.rb
@@ -11,7 +11,7 @@ module NetSuite
 
       fields :tran_date, :tran_id, :shipping_cost, :memo, :ship_company, :ship_attention, :ship_addr1,
         :ship_addr2, :ship_city, :ship_state, :ship_zip, :ship_phone, :ship_is_residential,
-        :ship_status, :last_modified_date, :created_date
+        :ship_status, :last_modified_date, :created_date, :status
 
       read_only_fields :handling_cost
 


### PR DESCRIPTION
Item Fulfillments in NetSuite have a `status` field that should be available via the record.