### PR TITLE
Setting wsdl_domain as Savon endpoint.

### DIFF
--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -26,6 +26,7 @@ module NetSuite
         logger: logger,
         log_level: log_level,
         log: !silent, # turn off logging entirely if configured
+        endpoint: wsdl_domain ## setting endpoint based on wsdl_domain
       }.update(params))
       cache_wsdl(client)
       return client


### PR DESCRIPTION
Netsuite made a change for some accounts causing Soap errors like:

```In this account, you must use account-specific domains with this SOAP web services endpoint. You can use the SOAP getDataCenterUrls operation to obtain the correct domain. Or, go to Setup &gt; Company &gt; Company Information in the NetSuite UI. Your domains are listed on the Company URLs tab.```

For that reason was needed to fork the [Netsuite](https://github.com/NetSweet/netsuite) gem in order to set the custom endpoint configured as `wsdl_domain` property in `Netsuite.configure` block.
