### PR TITLE
update classification segment to include parent record_ref

### DIFF
--- a/lib/netsuite/records/classification.rb
+++ b/lib/netsuite/records/classification.rb
@@ -16,6 +16,8 @@ module NetSuite
       attr_reader   :internal_id
       attr_accessor :external_id
 
+      record_refs :parent
+
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
         @external_id = attributes.delete(:external_id) || attributes.delete(:@external_id)

--- a/spec/netsuite/records/classification_spec.rb
+++ b/spec/netsuite/records/classification_spec.rb
@@ -13,6 +13,14 @@ describe NetSuite::Records::Classification do
     expect(classification.subsidiary_list.class).to eq(NetSuite::Records::RecordRefList)
   end
 
+  it 'has all the right record refs' do
+    [
+      :parent
+    ].each do |record_ref|
+      expect(classification).to have_record_ref(record_ref)
+    end
+  end
+
   describe '.get' do
     context 'when the response is successful' do
       let(:response) { NetSuite::Response.new(:success => true, :body => { :name => 'Retail' }) }


### PR DESCRIPTION
This was done to keep Classification consistent with Location and Department segments.

Fixes https://github.com/NetSweet/netsuite/issues/447