### PR TITLE
Add amount as a read_only_field to Invoice

### DIFF
--- a/lib/netsuite/records/invoice.rb
+++ b/lib/netsuite/records/invoice.rb
@@ -39,7 +39,7 @@ module NetSuite
       field :shipping_address,         Address
       field :billing_address,          Address
 
-      read_only_fields :sub_total, :discount_total, :total, :recognized_revenue, :amount_remaining, :amount_paid,
+      read_only_fields :sub_total, :discount_total, :total, :recognized_revenue, :amount_remaining, :amount_paid, :amount,
                        :alt_shipping_cost, :gift_cert_applied, :handling_cost, :alt_handling_cost
 
       record_refs :account, :bill_address_list, :custom_form, :department, :entity, :klass, :partner,


### PR DESCRIPTION
The Invoice object has an amount property in netsuite that can be
returned in transaction searches.  It should be available here too.