### PR TITLE
Pick up a commit from someone else's fork

### DIFF
--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -27,6 +27,7 @@ module NetSuite
         log_level: log_level,
         log: !silent, # turn off logging entirely if configured
       }.update(params))
+      client.wsdl.endpoint = client.wsdl.endpoint.to_s.sub('//webservices.netsuite.com/', "//#{wsdl_domain}/")
       cache_wsdl(client)
       return client
     end

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -94,6 +94,24 @@ describe NetSuite::Configuration do
       end
     end
 
+    context 'when the API and wsdl domain have been set on newer api versions' do
+      before do
+        config.sandbox = false
+        config.api_version '2019_1'
+        config.wsdl_domain = '4810331.suitetalk.api.netsuite.com'
+      end
+
+      it 'should correctly modify the full wsdl path' do
+        expect(config.wsdl).to eql('https://4810331.suitetalk.api.netsuite.com/wsdl/v2019_1_0/netsuite.wsdl')
+      end
+
+      it 'should override endpoint using wsdl_domain' do
+        # Override endpoint as netsuite wsdls starting with 2019_1 default to the webservices.netsuite.com
+        # endpoint even though it is not supported by newer api versions
+        expect(config.connection.wsdl.endpoint).to eql('https://4810331.suitetalk.api.netsuite.com/services/NetSuitePort_2019_1')
+      end
+    end
+
     context '#cache_wsdl' do
       it 'stores the client' do
         expect(config.wsdl_cache).to be_empty


### PR DESCRIPTION
This commit has been sitting in a PR against NetSweet/NetSuite for a
few months, but is necessary for this Gem to be usable at all with the
version of the API that we will be using.

- But that branch/PR has fallen behind master
- And I'd rather point to OdekoTeam's github to pick up an unreleased
  version of a Gem, rather than someone else's repo.

When these changes are released into the upstream NetSweet/NetSuite
proper, we can point our Gemfile at that.

original commit message from:
https://github.com/q3aiml/netsuite/tree/override-endpoint-using-wsdl-domain
https://github.com/q3aiml/netsuite/commit/1b6093a223e5db2c4ab9bffc284e550d9ebba214

fix "must use account-specific domains" error with newer API versions

Newer API versions require using the account-specific domains such as
`<account-id>.suitetalk.api.netsuite.com`. The WSDLs for these versions,
however, specify the generic `webservices.netsuite.com` domain. When
`wsdl_domain` is provided use this to override the endpoint so the
account-specific domain can be used and users can successfully use
2019_1.

I create the client first without the `endpoint` override to allow
reading the default endpoint from the client. Then `wsdl_domain` is
substituted into the default which avoids hardcoding the path in the gem
(`/services/NetsuitePort_#{api_version}`).