### PR TITLE
Fix deprecation warnings in custom_field_list_spec.rb

### DIFF
--- a/spec/netsuite/records/custom_field_list_spec.rb
+++ b/spec/netsuite/records/custom_field_list_spec.rb
@@ -37,9 +37,11 @@ describe NetSuite::Records::CustomFieldList do
   context 'writing convience methods' do
     it "should create a custom field entry when none exists" do
       list.custrecord_somefield = 'a value'
-      list.custom_fields.size.should == 1
-      list.custom_fields.first.value.should == 'a value'
-      list.custom_fields.first.type.should == 'platformCore:StringCustomFieldRef'
+      custom_fields = list.custom_fields
+
+      expect(custom_fields.size).to eq(1)
+      expect(custom_fields.first.value).to eq('a value')
+      expect(custom_fields.first.type).to eq('platformCore:StringCustomFieldRef')
     end
 
     # https://github.com/NetSweet/netsuite/issues/325
@@ -116,7 +118,7 @@ describe NetSuite::Records::CustomFieldList do
           end
 
           it "should raise an error if custom field entry does not exist" do
-            expect{ list.nonexisting_custom_field }.to raise_error
+            expect{ list.nonexisting_custom_field }.to raise_error(NoMethodError)
           end
         end
       end


### PR DESCRIPTION
* Specify the `NoMethodError` to keep RSpec happy and to ensure that
  other bugs don't sneak by as a passing test
* Upgrade single instance of `should` syntax to `expect`

Before:

```bash
dl@phoenix:~/src/netsuite (master)
$ rspec spec/netsuite/records/custom_field_list_spec.rb

Randomized with seed 16607
..........WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<NoMethodError: undefined method `nonexisting_custom_field' for #<NetSuite::Records::CustomFieldList:0x00007fd9c39ac9b0>>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/dl/src/netsuite/spec/netsuite/records/custom_field_list_spec.rb:119:in `block (6 levels) in <top (required)>'.
.......WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<NoMethodError: undefined method `nonexisting_custom_field' for #<NetSuite::Records::CustomFieldList:0x00007fd9c7055228>>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/dl/src/netsuite/spec/netsuite/records/custom_field_list_spec.rb:119:in `block (6 levels) in <top (required)>'.
.........WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<NoMethodError: undefined method `nonexisting_custom_field' for #<NetSuite::Records::CustomFieldList:0x00007fd9c39ced30>>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives = :nothing`. Called from /Users/dl/src/netsuite/spec/netsuite/records/custom_field_list_spec.rb:119:in `block (6 levels) in <top (required)>'.
.......

Deprecation Warnings:

Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }` instead. Called from /Users/dl/src/netsuite/spec/netsuite/records/custom_field_list_spec.rb:40:in `block (3 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total

Finished in 0.02508 seconds (files took 0.66762 seconds to load)
33 examples, 0 failures

Randomized with seed 16607
```

After

```bash
dl@phoenix:~/src/netsuite (fix-deprecation-warnings)
$ rspec spec/netsuite/records/custom_field_list_spec.rb

Randomized with seed 21304
.................................

Finished in 0.01778 seconds (files took 0.69159 seconds to load)
33 examples, 0 failures

Randomized with seed 21304
```