### PR TITLE
Allow `NetSuite::Configuration#log_level` to be reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,13 @@ NetSuite.configure do
   read_timeout  100_000
 
   # you can specify a file or file descriptor to send the log output to (defaults to STDOUT)
+  # If using within a Rails app, consider setting to `Rails.logger` to leverage existing
+  # application-level log configuration
   log           File.join(Rails.root, 'log/netsuite.log')
+
+  # Defaults to :debug level logging for Savon API calls. Decrease the verbosity
+  # by setting log_level to `:info`, for example
+  # log_level   :debug
 
   # password-based login information
   email    	  'email@domain.com'

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -373,12 +373,13 @@ module NetSuite
     end
 
     def log_level(value = nil)
-      self.log_level = value || :debug
-      attributes[:log_level]
+      self.log_level = value if value
+
+      attributes[:log_level] || :debug
     end
 
     def log_level=(value)
-      attributes[:log_level] ||= value
+      attributes[:log_level] = value
     end
   end
 end

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -326,15 +326,11 @@ describe NetSuite::Configuration do
 
   describe "#credentials" do
     context "when none are defined" do
-      skip "should properly create the auth credentials" do
-
-      end
+      skip "should properly create the auth credentials"
     end
 
     context "when they are defined" do
-      it "should properly replace the default auth credentials" do
-
-      end
+      skip "should properly replace the default auth credentials"
     end
   end
 

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -390,6 +390,26 @@ describe NetSuite::Configuration do
     end
   end
 
+  describe '#log_level' do
+    it 'defaults to :debug' do
+      expect(config.log_level).to eq(:debug)
+    end
+
+    it 'can be initially set to any log level' do
+      config.log_level(:info)
+
+      expect(config.log_level).to eq(:info)
+    end
+  end
+
+  describe '#log_level=' do
+    it 'can set the initial log_level' do
+      config.log_level = :info
+
+      expect(config.log_level).to eq(:info)
+    end
+  end
+
   describe 'timeouts' do
     it 'has defaults' do
       expect(config.read_timeout).to eql(60)

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -400,6 +400,16 @@ describe NetSuite::Configuration do
 
       expect(config.log_level).to eq(:info)
     end
+
+    it 'can override itself' do
+      config.log_level = :info
+
+      expect(config.log_level).to eq(:info)
+
+      config.log_level(:debug)
+
+      expect(config.log_level).to eq(:debug)
+    end
   end
 
   describe '#log_level=' do
@@ -407,6 +417,16 @@ describe NetSuite::Configuration do
       config.log_level = :info
 
       expect(config.log_level).to eq(:info)
+    end
+
+    it 'can override a previously set log level' do
+      config.log_level = :info
+
+      expect(config.log_level).to eq(:info)
+
+      config.log_level = :debug
+
+      expect(config.log_level).to eq(:debug)
     end
   end
 


### PR DESCRIPTION
## Problem

It’s surprising to not be able to, in a rails console, increase
the verbosity of the gem’s logging without needing to:

1. Tweak an ENV variable or otherwise change an initializer
2. Directly set `Configuration#attributes`

Aka, I would expect the following to work, but it does not.

```
app:staging> NetSuite::Configuration.log_level
=> :info
app:staging> NetSuite::Configuration.log_level = :debug
=> :debug
app:staging> NetSuite::Configuration.log_level
=> :info
```

Seems like the only way to increase the verbosity is to directly set
the appropriate attribute, which seems to be an internal data structure not intended
to be used by client code.

```
gravity:staging> NetSuite::Configuration.attributes[:log_level]
=> :info
gravity:staging> NetSuite::Configuration.attributes[:log_level] = :debug
=> :debug
gravity:staging> NetSuite::Configuration.log_level
=> :debug
```
## Solution

* Backfills some test coverage (f6fa522)
* Always set `attributes[:log_level]` when `log_level=` is called
* Support `log_level(value)` syntax via a short-circuit, similar to
  what's done in `#log(path)` and `#silent(value)`