### PR TITLE
CustomerPaymentCreditList

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -123,6 +123,8 @@ module NetSuite
     autoload :CustomerPayment,                  'netsuite/records/customer_payment'
     autoload :CustomerPaymentApply,             'netsuite/records/customer_payment_apply'
     autoload :CustomerPaymentApplyList,         'netsuite/records/customer_payment_apply_list'
+    autoload :CustomerPaymentCredit,            'netsuite/records/customer_payment_credit'
+    autoload :CustomerPaymentCreditList,        'netsuite/records/customer_payment_credit_list'
     autoload :CustomerPartner,                  'netsuite/records/customer_partner'
     autoload :CustomerRefund,                   'netsuite/records/customer_refund'
     autoload :CustomerRefundApply,              'netsuite/records/customer_refund_apply'

--- a/lib/netsuite/records/customer_payment.rb
+++ b/lib/netsuite/records/customer_payment.rb
@@ -17,7 +17,7 @@ module NetSuite
 
       field :custom_field_list, CustomFieldList
       field :apply_list,        CustomerPaymentApplyList
-      field :credit_list,        CustomerPaymentCreditList
+      field :credit_list,       CustomerPaymentCreditList
 
       read_only_fields :applied, :balance, :pending, :total, :unapplied
 

--- a/lib/netsuite/records/customer_payment.rb
+++ b/lib/netsuite/records/customer_payment.rb
@@ -17,6 +17,7 @@ module NetSuite
 
       field :custom_field_list, CustomFieldList
       field :apply_list,        CustomerPaymentApplyList
+      field :credit_list,        CustomerPaymentCreditList
 
       read_only_fields :applied, :balance, :pending, :total, :unapplied
 

--- a/lib/netsuite/records/customer_payment_credit.rb
+++ b/lib/netsuite/records/customer_payment_credit.rb
@@ -1,0 +1,17 @@
+module NetSuite
+  module Records
+    class CustomerPaymentCredit
+      include Support::Fields
+      include Support::Records
+      include Namespaces::TranCust
+
+      fields :amount, :applied_to, :apply, :credit_date, :currency, :doc, :due, :line,
+        :ref_num, :total, :type
+
+      def initialize(attributes = {})
+        initialize_from_attributes_hash(attributes)
+      end
+
+    end
+  end
+end

--- a/lib/netsuite/records/customer_payment_credit_list.rb
+++ b/lib/netsuite/records/customer_payment_credit_list.rb
@@ -1,0 +1,12 @@
+module NetSuite
+  module Records
+    class CustomerPaymentCreditList < Support::Sublist
+      include Namespaces::TranCust
+
+      sublist :credit, CustomerPaymentCredit
+
+      alias :credits :credit
+
+    end
+  end
+end

--- a/lib/netsuite/records/purchase_order.rb
+++ b/lib/netsuite/records/purchase_order.rb
@@ -14,7 +14,7 @@ module NetSuite
              :linked_tracking_numbers, :memo, :message, :other_ref_num, :ship_date,
              :ship_is_residential, :ship_to, :source, :status, :sub_total, :supervisor_approval,
              :tax2_total, :tax_total, :to_be_emailed, :to_be_faxed, :to_be_printed,
-             :total, :tracking_numbers, :tran_date, :tran_id, :vat_reg_num, :line_unique_key, :item
+             :total, :tracking_numbers, :tran_date, :tran_id, :vat_reg_num
 
       field :billing_address,   Address
       field :shipping_address,  Address

--- a/lib/netsuite/records/purchase_order.rb
+++ b/lib/netsuite/records/purchase_order.rb
@@ -14,7 +14,7 @@ module NetSuite
              :linked_tracking_numbers, :memo, :message, :other_ref_num, :ship_date,
              :ship_is_residential, :ship_to, :source, :status, :sub_total, :supervisor_approval,
              :tax2_total, :tax_total, :to_be_emailed, :to_be_faxed, :to_be_printed,
-             :total, :tracking_numbers, :tran_date, :tran_id, :vat_reg_num
+             :total, :tracking_numbers, :tran_date, :tran_id, :vat_reg_num, :line_unique_key, :item
 
       field :billing_address,   Address
       field :shipping_address,  Address

--- a/spec/netsuite/records/customer_payment_credit_list_spec.rb
+++ b/spec/netsuite/records/customer_payment_credit_list_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe NetSuite::Records::CustomerPaymentCreditList do
+  let(:list) { NetSuite::Records::CustomerPaymentCreditList.new }
+  let(:apply) { NetSuite::Records::CustomerPaymentCredit.new }
+
+  it 'can have credits be added to it' do
+    list.credits << credit
+    credit_list = list.credits
+    expect(credit_list).to be_kind_of(Array)
+    expect(credit_list.length).to eql(1)
+    credit_list.each { |i| expect(i).to be_kind_of(NetSuite::Records::CustomerPaymentCredit) }
+  end
+
+  describe '#to_record' do
+    it 'can represent itself as a SOAP record' do
+      record = {
+          'tranCust:credit' => [{},{}]
+      }
+      list.credits.concat([credit,credit])
+      expect(list.to_record).to eql(record)
+    end
+  end
+
+end


### PR DESCRIPTION
Kinda confused because I didn't see this `Record` type, however, the following already existed in `customer_payment_spec.rb`:

```
  describe '#credit_list' do
    it 'can be set from attributes'
    it 'can be set from a CustomerPaymentCreditList object'
  end
```