### PR TITLE
Update fields/record refs on partner record to match 2020.2 schema

### DIFF
--- a/lib/netsuite/records/partner.rb
+++ b/lib/netsuite/records/partner.rb
@@ -8,15 +8,17 @@ module NetSuite
       include Support::RecordRefs
       include Namespaces::ListRel
 
-      # https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2014_1/schema/record/partner.html
+      # https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2020_2/schema/record/partner.html
 
       actions :get, :get_list, :add, :update, :upsert, :upsert_list, :delete, :search
 
-      fields :phone, :home_phone, :first_name, :last_name, :alt_name, :is_inactive, :email, :give_access,
-             :partner_code, :is_person, :company_name, :eligible_for_commission, :entity_id, :last_modified_date,
-             :date_created, :title, :mobile_phone, :comments, :middle_name, :send_email, :password, :password2
+      fields :alt_email, :alt_name, :bcn, :comments, :company_name, :date_created, :default_address,
+             :eligible_for_commission, :email, :entity_id, :fax, :first_name, :give_access, :home_phone, :is_inactive,
+             :is_person, :last_modified_date, :last_name, :login_as, :middle_name, :mobile_phone, :partner_code,
+             :password, :password2, :phone, :phonetic_name, :print_on_check_as, :referring_url, :require_pwd_change,
+             :salutation, :send_email, :sub_partner_login, :tax_id_num, :title, :url, :vat_reg_number
 
-      record_refs :klass, :access_role, :department, :subsidiary
+      record_refs :access_role, :klass, :custom_form, :default_tax_reg, :department, :image, :location, :parent, :subsidiary
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/spec/netsuite/records/partner_spec.rb
+++ b/spec/netsuite/records/partner_spec.rb
@@ -5,9 +5,11 @@ describe NetSuite::Records::Partner do
 
   it 'has all the right fields' do
     [
-        :phone, :home_phone, :first_name, :last_name, :alt_name, :is_inactive, :email, :give_access,
-        :partner_code, :is_person, :company_name, :eligible_for_commission, :entity_id, :last_modified_date,
-        :date_created, :title, :mobile_phone, :comments, :middle_name, :send_email, :password, :password2
+        :alt_email, :alt_name, :bcn, :comments, :company_name, :date_created, :default_address,
+        :eligible_for_commission, :email, :entity_id, :fax, :first_name, :give_access, :home_phone, :is_inactive,
+        :is_person, :last_modified_date, :last_name, :login_as, :middle_name, :mobile_phone, :partner_code,
+        :password, :password2, :phone, :phonetic_name, :print_on_check_as, :referring_url, :require_pwd_change,
+        :salutation, :send_email, :sub_partner_login, :tax_id_num, :title, :url, :vat_reg_number
     ].each do |field|
       expect(partner).to have_field(field)
     end
@@ -15,7 +17,7 @@ describe NetSuite::Records::Partner do
 
   it 'has all the right record refs' do
     [
-        :klass, :access_role, :department, :subsidiary
+        :access_role, :klass, :custom_form, :default_tax_reg, :department, :image, :location, :parent, :subsidiary
     ].each do |record_ref|
       expect(partner).to have_record_ref(record_ref)
     end


### PR DESCRIPTION
Thanks for this gem. I started my first integration with NetSuite and this was a huge time saver!

My integration touched on partners and I noticed the field list and record refs were outdated compared to the 2020.2 schema, so this should bring the gem inline with that schema.