### PR TITLE
fix MultiSelectCustomFieldRef Custom Fields to correctly extract as an array with 1 valid CustomRecordRef entry

### DIFF
--- a/lib/netsuite/records/custom_field_list.rb
+++ b/lib/netsuite/records/custom_field_list.rb
@@ -113,8 +113,13 @@ module NetSuite
             if type == "platformCore:SelectCustomFieldRef"
               attrs[:value] = CustomRecordRef.new(custom_field_data[:value])
             elsif type == 'platformCore:MultiSelectCustomFieldRef'
-              attrs[:value] = custom_field_data[:value].map do |entry|
-                CustomRecordRef.new(entry)
+              attrs[:value] = case custom_field_data[:value]
+                when Hash
+                  [CustomRecordRef.new(custom_field_data[:value])]
+                when Array
+                  custom_field_data[:value].map do |entry|
+                    CustomRecordRef.new(entry)
+                  end
               end
             end
 


### PR DESCRIPTION
MultiSelectCustomFieldRef Custom Fields with only 1 selection aren't extracted correctly. 

The extraction code assumes that MultiSelectCustomFieldRef values are always an array, but when it's a single selection the direct hash of the value is sent instead.

The problem is this code:

```ruby
attrs[:value] = custom_field_data[:value].map do |entry|
    CustomRecordRef.new(entry)
end
```

For cases with multiple selections, `custom_field_data[:value]` contains `[{:name=>"Apple", :@internal_id=>"1", :@type_id=>"108"}, {:name=>"Orange", :@internal_id=>"4", :@type_id=>"108"}]`, and `.map` proceeds as expected. However, when a single value is selected, then `custom_field_data[:value]` is `{:name=>"Apple", :@internal_id=>"4", :@type_id=>"108"}` and `.map` sends each key/value pair to `CustomRecordRef.new`, which creates 3 broken custom refs.

The fix is to recognize that a Hash is being sent, and transform it into a single element array.


### Single Selection Scenario That Fails

The xml sent from NetSuite:
```xml
<platformCore:customField internalId="1045" scriptId="cust_fruit_selections" xsi:type="platformCore:MultiSelectCustomFieldRef">
  <platformCore:value internalId="4" typeId="108">
    <platformCore:name>Apple</platformCore:name>
  </platformCore:value>
</platformCore:customField>
```

The resulting `custom_field_data[:value]` is `{:name=>"Apple", :@internal_id=>"4", :@type_id=>"108"}`. After parsing the resulting data structure is (incorrectly):

```ruby
=> #<NetSuite::Records::CustomField:0x000
 @attributes=
  {:value=>
    [#<NetSuite::Records::CustomRecordRef:0x00...>,
     #<NetSuite::Records::CustomRecordRef:0x00...>,
     #<NetSuite::Records::CustomRecordRef:0x00...>]},
 @internal_id="1045",
 @script_id="cust_fruit_selections",
 @type="platformCore:MultiSelectCustomFieldRef">
 ```

 ### Multi Value Scenario That Works

The xml sent from NetSuite:

```xml
<platformCore:customField internalId="1045" scriptId="cust_fruit_selections" xsi:type="platformCore:MultiSelectCustomFieldRef">
  <platformCore:value internalId="1" typeId="108">
    <platformCore:name>Orange</platformCore:name>
  </platformCore:value>
  <platformCore:value internalId="4" typeId="108">
    <platformCore:name>Apple</platformCore:name>
  </platformCore:value>
</platformCore:customField>
```

The resulting `custom_field_data[:value]` is `[{:name=>"Apple", :@internal_id=>"1", :@type_id=>"108"}, {:name=>"Orange", :@internal_id=>"4", :@type_id=>"108"}]`. After parsing the resulting data structure is:

```ruby
=> #<NetSuite::Records::CustomField:0x00...
 @attributes=
  {:value=>
    [#<NetSuite::Records::CustomRecordRef:0x00... @attributes={:name=>"Orange"}, @external_id=nil, @internal_id="1", @type_id="108">,
     #<NetSuite::Records::CustomRecordRef:0x00... @attributes={:name=>"Apple"}, @external_id=nil, @internal_id="4", @type_id="108">]},
 @internal_id="1045",
 @script_id="cust_fruit_selections",
 @type="platformCore:MultiSelectCustomFieldRef">
```

