### PR TITLE
Add payment_option to CustomerPayment and CustomerDeposit

### DIFF
--- a/lib/netsuite/records/customer_deposit.rb
+++ b/lib/netsuite/records/customer_deposit.rb
@@ -21,11 +21,11 @@ module NetSuite
       field :apply_list,        CustomerDepositApplyList
       # accountingBookDetailList
 
-      record_refs :customer, :sales_order, :account, :department, :payment_method,
-                  :custom_form, :currency, :posting_period, :subsidiary, :location,
-
-                  # only available in an advanced search result
-                  :deposit_transaction
+      record_refs :customer, :sales_order, :account, :department,
+        :payment_method, :payment_option, :custom_form, :currency,
+        :posting_period, :subsidiary, :location,
+        # only available in an advanced search result
+        :deposit_transaction
 
       attr_reader :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/customer_payment.rb
+++ b/lib/netsuite/records/customer_payment.rb
@@ -21,8 +21,10 @@ module NetSuite
 
       read_only_fields :applied, :balance, :pending, :total, :unapplied
 
-      record_refs :account, :ar_acct, :credit_card, :credit_card_processor, :custom_form, :customer, :department, :klass,
-        :location, :payment_method, :posting_period, :subsidiary, :currency
+      record_refs :account, :ar_acct, :credit_card, :credit_card_processor,
+        :custom_form, :customer, :department, :klass, :location,
+        :payment_method, :payment_option, :posting_period, :subsidiary,
+        :currency
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/spec/netsuite/records/customer_payment_spec.rb
+++ b/spec/netsuite/records/customer_payment_spec.rb
@@ -18,7 +18,7 @@ describe NetSuite::Records::CustomerPayment do
 
   it 'has all the right record refs' do
     [
-      :account, :ar_acct, :credit_card, :credit_card_processor, :custom_form, :customer, :department, :klass, :location, :payment_method, :posting_period, :subsidiary
+      :account, :ar_acct, :credit_card, :credit_card_processor, :custom_form, :customer, :department, :klass, :location, :payment_method, :payment_option, :posting_period, :subsidiary
     ].each do |record_ref|
       expect(payment).to have_record_ref(record_ref)
     end


### PR DESCRIPTION
NS exposes a `paymentOption` recordRef field on both the [CustomerPayment](https://www.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2020_2/schema/record/customerpayment.html) and [CustomerDeposit](https://www.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2020_2/schema/record/customerdeposit.html) records. This PR adds support for it.

I manually tested these changes with a console and was able to read/write to the field to a live NS instance. I also updated the CustomerPayment test to ensure this field covered.

Tests pass for me locally:

<img width="431" alt="image" src="https://user-images.githubusercontent.com/7997618/108902251-e08b7e00-75e9-11eb-865e-de6c47e8cc95.png">
