### PR TITLE
Enable `endpoint` as a configuration option to bypass NS WSDL issues

### DIFF
--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -17,6 +17,7 @@ module NetSuite
     def connection(params={}, credentials={})
       client = Savon.client({
         wsdl: cached_wsdl || wsdl,
+        endpoint: endpoint,
         read_timeout: read_timeout,
         open_timeout: open_timeout,
         namespaces: namespaces,
@@ -92,6 +93,18 @@ module NetSuite
       end
 
       attributes[:api_version] = version
+    end
+
+    def endpoint=(endpoint)
+      attributes[:endpoint] = endpoint
+    end
+
+    def endpoint(endpoint=nil)
+      if endpoint
+        self.endpoint = endpoint
+      else
+        attributes[:endpoint]
+      end
     end
 
     def sandbox=(flag)

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -29,10 +29,12 @@ describe NetSuite::Configuration do
   end
 
   describe '#connection' do
+    EXAMPLE_ENDPOINT = 'https://1023.suitetalk.api.netsuite.com/services/NetSuitePort_2020_2'
     before(:each) do
       # reset clears out the password info
       config.email       'me@example.com'
       config.password    'me@example.com'
+      config.endpoint    EXAMPLE_ENDPOINT
       config.account     1023
       config.wsdl        "my_wsdl"
       config.api_version "2012_2"
@@ -56,6 +58,19 @@ describe NetSuite::Configuration do
       config.connection
 
       expect(config).to have_received(:cached_wsdl)
+    end
+
+    it 'sets the endpoint on the Savon client' do
+      # this is ugly/brittle, but it's hard to see how else to test this
+      savon_configs = config.connection.globals.instance_eval {@options}
+      expect(savon_configs.fetch(:endpoint)).to eq(EXAMPLE_ENDPOINT)
+    end
+
+    it 'handles a nil endpoint' do
+      config.endpoint = nil
+      # this is ugly/brittle, but it's hard to see how else to test this
+      savon_configs = config.connection.globals.instance_eval {@options}
+      expect(savon_configs.fetch(:endpoint)).to eq(nil)
     end
   end
 
@@ -163,6 +178,23 @@ describe NetSuite::Configuration do
         expect(config.wsdl_cache).to be_empty
         expect( config.cached_wsdl ).to eq nil
       end
+    end
+  end
+
+  describe '#endpoint' do
+    it 'can be set with endpoint=' do
+      config.endpoint = 42
+      expect(config.endpoint).to eq(42)
+    end
+
+    it 'can be set with just endpoint(value)' do
+      config.endpoint(42)
+      expect(config.endpoint).to eq(42)
+    end
+
+    it 'supports nil endpoints' do
+      config.endpoint = nil
+      expect(config.endpoint).to eq(nil)
     end
   end
 


### PR DESCRIPTION
### Background

This is related to https://github.com/NetSweet/netsuite/pull/445, which I believe first raised this issue.

Recent versions of the NS WSDL contain an incorrect endpoint reference. This seems to have begun on version 2020_1. If you go to `https://<acount_id>.suitetalk.api.netsuite.com/wsdl/v2020_1_0/netsuite.wsdl` you can see at the very bottom:

![image](https://user-images.githubusercontent.com/7997618/109563656-0fa06480-7aae-11eb-8055-85fb6c1a434b.png)

When requests are made to this endpoint the following error is returned:

> In this account, you must use account-specific domains with this SOAP web services endpoint. You can use the SOAP getDataCenterUrls operation to obtain the correct domain. Or, go to Setup > Company > Company Information in the NetSuite UI. Your domains are listed on the Company URLs tab.

### Solution

To fix, I added a configuration option to set the WSDL endpoint:

```ruby
NetSuite.configure do
  endpoint "https://123456.suitetalk.api.netsuite.com/services/NetSuitePort_2020_1"
end

# or, equivalently
NetSuite::Configuration.endpoint = "https://123456.suitetalk.api.netsuite.com/services/NetSuitePort_2020_1"

# or, to future-proof it
NetSuite::Configuration.endpoint = "#{wsdl_domain}/services/NetSuitePort_#{api_verson}"
```

This option is passed through to the Savon::Client at the time of client instantiation. Savon then reads the endpoint from its global config when it is [building the request](https://github.com/savonrb/savon/blob/0ae76da35420a6fa65fdfefa512b13d8a9a1d3e5/lib/savon/operation.rb#L90-L92):

```ruby
  def build_request(builder)
      @locals[:soap_action] ||= soap_action
      @globals[:endpoint] ||= endpoint

      request = SOAPRequest.new(@globals).build(
        :soap_action => soap_action,
        :cookies     => @locals[:cookies],
        :headers     => @locals[:headers]
      )

      request.url = endpoint
```

Note that the `endpoint` configuration is optional, and [Savon ignores nil `endpoint` configs](https://github.com/savonrb/savon/blob/0ae76da35420a6fa65fdfefa512b13d8a9a1d3e5/lib/savon/operation.rb#L131-L139) in favor of the endpoint defined on the WSDL document:

```ruby
    def endpoint
      @globals[:endpoint] || @wsdl.endpoint.tap do |url|
        if @globals[:host]
          host_url = URI.parse(@globals[:host])
          url.host = host_url.host
          url.port = host_url.port
        end
      end
    end
```

So this should be backwards compatible.

### Testing

I added automated tests. But the nature of the change makes it hard to really test without deeply mocking private methods of Savon classes. So the best tests are probably manual.

By loading these changes into a console I was able to get a record on the 2020_1 version of the NS API:

```xml
irb(main):484:0> NetSuite::Configuration.endpoint = "https://1234567.suitetalk.api.netsuite.com/services/NetSuitePort_2020_1"
=> "https://1234567.suitetalk.api.netsuite.com/services/NetSuitePort_2020_1"
irb(main):485:0> cp = NetSuite::Records::CustomerPayment.get(external_id: "xxxxxxxxxx")


I, [2021-03-01T21:36:44.220119 #4]  INFO -- : SOAP request: https://1234567.suitetalk.api.netsuite.com/services/NetSuitePort_2020_1
I, [2021-03-01T21:36:44.220236 #4]  INFO -- : SOAPAction: "get", Content-Type: text/xml;charset=UTF-8, Content-Length: 1293
D, [2021-03-01T21:36:44.221013 #4] DEBUG -- : <?xml version="1.0" encoding="UTF-8"?>
<env:Envelope xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:platformMsgs="urn:messages_2020_1.platform.webservices.netsuite.com" xmlns:env="http://schemas.xmlsoap.org/soap/envelope/" xmlns:platformCore="urn:core_2020_1.platform.webservices.netsuite.com">
  <env:Header>
    <platformMsgs:tokenPassport>
      <platformCore:account>1234567</platformCore:account>
      <platformCore:consumerKey>***FILTERED***</platformCore:consumerKey>
      <platformCore:token>***FILTERED***</platformCore:token>
      <platformCore:nonce>xxxxxxxxxxxx</platformCore:nonce>
      <platformCore:timestamp>1614634604</platformCore:timestamp>
      <platformCore:signature algorithm="HMAC-SHA256">xxxxxxxxxx</platformCore:signature>
    </platformMsgs:tokenPassport>
    <platformMsgs:preferences>
      <platformMsgs:ignoreReadOnlyFields>true</platformMsgs:ignoreReadOnlyFields>
    </platformMsgs:preferences>
  </env:Header>
  ...
```

Note that the request is sent to the desired endpoint: `https://1234567.suitetalk.api.netsuite.com/services/NetSuitePort_2020_1`