### PR TITLE
Accounting period closed

### DIFF
--- a/lib/netsuite/records/accounting_period.rb
+++ b/lib/netsuite/records/accounting_period.rb
@@ -8,7 +8,7 @@ module NetSuite
 
       actions :get, :get_list, :add, :delete, :upsert, :search
 
-      fields :allow_non_gl_changes, :end_date, :is_adjust, :is_quarter, :is_year, :period_name, :start_date
+      fields :allow_non_gl_changes, :end_date, :is_adjust, :is_quarter, :is_year, :period_name, :start_date, :closed
 
       record_refs :parent
 

--- a/lib/netsuite/records/accounting_period.rb
+++ b/lib/netsuite/records/accounting_period.rb
@@ -13,7 +13,7 @@ module NetSuite
       record_refs :parent
 
       attr_reader :internal_id
-      attr_accessor :external_id
+      attr_accessor :external_id, :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/purchase_order.rb
+++ b/lib/netsuite/records/purchase_order.rb
@@ -14,7 +14,7 @@ module NetSuite
              :linked_tracking_numbers, :memo, :message, :other_ref_num, :ship_date,
              :ship_is_residential, :ship_to, :source, :status, :sub_total, :supervisor_approval,
              :tax2_total, :tax_total, :to_be_emailed, :to_be_faxed, :to_be_printed,
-             :total, :tracking_numbers, :tran_date, :tran_id, :vat_reg_num, :line_unique_key, :item
+             :total, :tracking_numbers, :tran_date, :tran_id, :vat_reg_num
 
       field :billing_address,   Address
       field :shipping_address,  Address

--- a/lib/netsuite/records/purchase_order.rb
+++ b/lib/netsuite/records/purchase_order.rb
@@ -14,7 +14,7 @@ module NetSuite
              :linked_tracking_numbers, :memo, :message, :other_ref_num, :ship_date,
              :ship_is_residential, :ship_to, :source, :status, :sub_total, :supervisor_approval,
              :tax2_total, :tax_total, :to_be_emailed, :to_be_faxed, :to_be_printed,
-             :total, :tracking_numbers, :tran_date, :tran_id, :vat_reg_num
+             :total, :tracking_numbers, :tran_date, :tran_id, :vat_reg_num, :line_unique_key, :item
 
       field :billing_address,   Address
       field :shipping_address,  Address

--- a/spec/netsuite/records/customer_payment_credit_list_spec.rb
+++ b/spec/netsuite/records/customer_payment_credit_list_spec.rb
@@ -7,7 +7,6 @@ describe NetSuite::Records::CustomerPaymentCreditList do
   it 'can have credits be added to it' do
     list.credits << apply
     credit_list = list.credits
-
     expect(credit_list).to be_kind_of(Array)
     expect(credit_list.length).to eql(1)
     credit_list.each { |i| expect(i).to be_kind_of(NetSuite::Records::CustomerPaymentCredit) }


### PR DESCRIPTION
Only way to get the `closed` attribute (which does not appear on a simple `get`) for an `AccountingPeriod` is to request it as a column as part of an Advanced Search. This makes that possible.