### PR TITLE
Include protocol in readme examples setting endpoint from wsdl_domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ NetSuite.configure do
   # the endpoint indicated in the > 2018_2 wsdl is invalid
   # you must set the endpoint directly
   # https://github.com/NetSweet/netsuite/pull/473
-  endpoint "#{wsdl_domain}/services/NetSuitePort_#{api_version}"
+  endpoint "https://#{wsdl_domain}/services/NetSuitePort_#{api_version}"
 end
 ```
 
@@ -173,7 +173,7 @@ NetSuite.configure do
   # the endpoint indicated in the > 2018_2 wsdl is invalid
   # you must set the endpoint directly
   # https://github.com/NetSweet/netsuite/pull/473
-  endpoint "#{wsdl_domain}/services/NetSuitePort_#{api_version}"
+  endpoint "https://#{wsdl_domain}/services/NetSuitePort_#{api_version}"
 end
 ```
 


### PR DESCRIPTION
The `wsdl_domain` is just a domain/hostname, no protocol, however `endpoint` expects to include a protocol, so when you're buliding the `endpoint` from the `wsdl_domain`, you need to prefix it with a protocol.

#473 introduced the ability to set the `endpoint`.