### PR TITLE
Properly extract external_id from advanced search results

### DIFF
--- a/lib/netsuite/support/search_result.rb
+++ b/lib/netsuite/support/search_result.rb
@@ -89,6 +89,10 @@ module NetSuite
                 record[:basic][:internal_id] = record[:basic][:internal_id][:@internal_id]
               end
 
+              if record[:basic][:external_id]
+                record[:basic][:external_id] = record[:basic][:external_id][:@external_id]
+              end
+
               result_wrapper = result_class.new(record.delete(:basic))
               result_wrapper.search_joins = record
               results << result_wrapper

--- a/spec/netsuite/actions/search_spec.rb
+++ b/spec/netsuite/actions/search_spec.rb
@@ -168,6 +168,8 @@ describe NetSuite::Actions::Search do
 
       expect(search.results.size).to eq(2)
       expect(search.current_page).to eq(1)
+      expect(search.results.first.internal_id).to eq('123')
+      expect(search.results.first.external_id).to eq('456')
       expect(search.results.first.alt_name).to eq('A Awesome Name')
       expect(search.results.last.email).to eq('alessawesome@gmail.com')
     end

--- a/spec/support/fixtures/search/saved_search_joined_custom_customer.xml
+++ b/spec/support/fixtures/search/saved_search_joined_custom_customer.xml
@@ -16,6 +16,12 @@
         <platformCore:searchRowList>
           <platformCore:searchRow xmlns:listRel="urn:relationships_2012_1.lists.webservices.netsuite.com" xsi:type="listRel:CustomerSearchRow">
             <listRel:basic xmlns:platformCommon="urn:common_2012_1.platform.webservices.netsuite.com">
+              <platformCommon:internalId>
+                <platformCore:searchValue internalId="123"/>
+              </platformCommon:internalId>
+              <platformCommon:externalId>
+                <platformCore:searchValue externalId="456"/>
+              </platformCommon:externalId>
               <platformCommon:altName>
                 <platformCore:searchValue>A Awesome Name</platformCore:searchValue>
               </platformCommon:altName>


### PR DESCRIPTION
If you performed an advanced search specifying which columns to return and included externalId, you wouldn't be able to get the external_id from the resulting record via the usual external_id method. This now matches how internal_id is extracted.

Prior to this, calls to external_id returned:
```
> record.external_id
=> {:@external_id=>"customer_1"}
```

Now, it returns:
```
> record.external_id
=> "customer_1"
```

This originally surfaced in #470 as part of a larger change, but we're exploring taking that in a different direction, so extracted this out to it's own PR.