### PR TITLE
Update readme for including custom fields in search result columns for API 2013.2 and newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,9 @@ NetSuite::Records::SalesOrder.search({
     'tranSales:itemJoin' => [
       'platformCommon:customFieldList' => [
         'platformCore:customField/' => {
-          '@internalId' => 'custitem_apcategoryforsales',
+          '@scriptId' => 'custitem_apcategoryforsales',
+          # Or, for API versions 2013.1 and older:
+          # '@internalId' => 'custitem_apcategoryforsales',
           '@xsi:type' => "platformCore:SearchColumnSelectCustomField"
         }
       ]


### PR DESCRIPTION
These newer API versions expect the field to be identified by its scriptId, not internalId.