### PR TITLE
Add CostCategory record

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -95,6 +95,7 @@ module NetSuite
     autoload :CashRefundItemList,               'netsuite/records/cash_refund_item_list'
     autoload :Campaign,                         'netsuite/records/campaign'
     autoload :Classification,                   'netsuite/records/classification'
+    autoload :CostCategory,                     'netsuite/records/cost_category'
     autoload :CreditMemo,                       'netsuite/records/credit_memo'
     autoload :CreditMemoApply,                  'netsuite/records/credit_memo_apply'
     autoload :CreditMemoApplyList,              'netsuite/records/credit_memo_apply_list'

--- a/lib/netsuite/records/cost_category.rb
+++ b/lib/netsuite/records/cost_category.rb
@@ -1,0 +1,28 @@
+module NetSuite
+  module Records
+    class CostCategory
+      include Support::Fields
+      include Support::RecordRefs
+      include Support::Records
+      include Support::Actions
+      include Namespaces::ListAcct
+
+      actions :add, :delete, :delete_list, :get, :get_all, :get_list, :get_select_value, :search, :update, :update_list, :upsert, :upsert_list
+      # TODO: Add add_list when supported by gem
+
+      fields :is_inactive, :item_cost_type, :name
+
+      record_refs :account
+
+      attr_reader :internal_id
+      attr_accessor :external_id
+
+      def initialize(attributes = {})
+        @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
+        @external_id = attributes.delete(:external_id) || attributes.delete(:@external_id)
+        initialize_from_attributes_hash(attributes)
+      end
+
+    end
+  end
+end

--- a/spec/netsuite/records/cost_category_spec.rb
+++ b/spec/netsuite/records/cost_category_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+
+describe NetSuite::Records::CostCategory do
+  let(:cost_category) { described_class.new }
+
+  it 'has all the right fields' do
+    [
+      :is_inactive,
+      :item_cost_type,
+      :name,
+    ].each do |field|
+      expect(cost_category).to have_field(field)
+    end
+  end
+
+  it 'has all the right record refs' do
+    [
+      :account,
+    ].each do |record_ref|
+      expect(cost_category).to have_record_ref(record_ref)
+    end
+  end
+
+  describe '.get' do
+    context 'when the response is successful' do
+      let(:response) { NetSuite::Response.new(:success => true, :body => { :name => 'CostCategory 1' }) }
+
+      it 'returns a CostCategory instance populated with the data from the response object' do
+        expect(NetSuite::Actions::Get).to receive(:call).with([described_class, {:external_id => 1}], {}).and_return(response)
+        cost_category = described_class.get(:external_id => 1)
+        expect(cost_category).to be_kind_of(described_class)
+        expect(cost_category.name).to eql('CostCategory 1')
+      end
+    end
+
+    context 'when the response is unsuccessful' do
+      let(:response) { NetSuite::Response.new(:success => false, :body => {}) }
+
+      it 'raises a RecordNotFound exception' do
+        expect(NetSuite::Actions::Get).to receive(:call).with([described_class, {:external_id => 1}], {}).and_return(response)
+        expect {
+          described_class.get(:external_id => 1)
+        }.to raise_error(NetSuite::RecordNotFound,
+          /NetSuite::Records::CostCategory with OPTIONS=(.*) could not be found/)
+      end
+    end
+  end
+
+  describe '#add' do
+    let(:test_data) { { :name => 'Test CostCategory' } }
+
+    context 'when the response is successful' do
+      let(:response) { NetSuite::Response.new(:success => true, :body => { :internal_id => '1' }) }
+
+      it 'returns true' do
+        cost_category = described_class.new(test_data)
+        expect(NetSuite::Actions::Add).to receive(:call).
+            with([cost_category], {}).
+            and_return(response)
+        expect(cost_category.add).to be_truthy
+      end
+    end
+
+    context 'when the response is unsuccessful' do
+      let(:response) { NetSuite::Response.new(:success => false, :body => {}) }
+
+      it 'returns false' do
+        cost_category = described_class.new(test_data)
+        expect(NetSuite::Actions::Add).to receive(:call).
+            with([cost_category], {}).
+            and_return(response)
+        expect(cost_category.add).to be_falsey
+      end
+    end
+  end
+
+  describe '#delete' do
+    let(:test_data) { { :internal_id => '1' } }
+
+    context 'when the response is successful' do
+      let(:response)  { NetSuite::Response.new(:success => true, :body => { :internal_id => '1' }) }
+
+      it 'returns true' do
+        cost_category = described_class.new(test_data)
+        expect(NetSuite::Actions::Delete).to receive(:call).
+            with([cost_category], {}).
+            and_return(response)
+        expect(cost_category.delete).to be_truthy
+      end
+    end
+
+    context 'when the response is unsuccessful' do
+      let(:response) { NetSuite::Response.new(:success => false, :body => {}) }
+
+      it 'returns false' do
+        cost_category = described_class.new(test_data)
+        expect(NetSuite::Actions::Delete).to receive(:call).
+            with([cost_category], {}).
+            and_return(response)
+        expect(cost_category.delete).to be_falsey
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This is an accounting list, like Term.

I copied the get, add, delete specs from the Term spec, but it seems a little redundant to repeat these on each record. Maybe it'd be better to have an "action matcher", like the "field matcher", to assert the right actions were defined, not testing the implementation of those actions, leaving that to the action-specific specs?