### PR TITLE
Explain search only fields in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,10 @@ NetSuite::Records::SalesOrder.search({
     'tranSales:basic' => [
       'platformCommon:internalId/' => {},
       'platformCommon:email/' => {},
-      'platformCommon:tranDate/' => {}
+      'platformCommon:tranDate/' => {},
+      # If you include columns that are only part of the *SearchRowBasic (ie. TransactionSearchRowBasic), 
+      # they'll be readable on the resulting record just like regular fields (my_record.close_date).
+      'platformCommon:closeDate/' => {}
     ],
     'tranSales:accountJoin' => [
       'platformCommon:internalId/' => {}


### PR DESCRIPTION
Attempt to document #483.

I wasn't sure how best to convey this given it affects consuming the search results, not performing the search itself. It should also be unsurprising that you'd access these search-only fields the same way you'd access regular or read-only fields.

Had we buried these search-only fields in custom fields, like #426 first attempted, then I'd find that more surprising and warranting clearer documentation.