### PR TITLE
return-netsuite-error-for-search-action-failures

### DIFF
--- a/lib/netsuite/actions/search.rb
+++ b/lib/netsuite/actions/search.rb
@@ -244,7 +244,7 @@ module NetSuite
             if response.success?
               NetSuite::Support::SearchResult.new(response, self, credentials)
             else
-              false
+              NetSuite::Error.new(response.body[:status][:status_detail])
             end
           end
         end


### PR DESCRIPTION
Why
Currently, if the response of the `Search` action is not successful, it will simply return `false` and give no insight into what the issue was.
Looking at patterns implemented elsewhere in the codebase, we seem to be moving towards returning a `NetSuite::Error` if the response is not successful.

Solution
Implement returning a `NetSuite::Error` if the response is not successful.