### PR TITLE
Avoid repeating field definitions

### DIFF
--- a/lib/netsuite/records/assembly_unbuild.rb
+++ b/lib/netsuite/records/assembly_unbuild.rb
@@ -12,7 +12,7 @@ module NetSuite
         :search
 
       fields :bin_numbers, :built, :created_date, :expiration_date,
-        :last_modified_date, :memo, :quantity, :serial_numbers, :total,
+        :last_modified_date, :memo, :quantity, :serial_numbers,
         :tran_date, :tran_id
 
 	  read_only_fields :total
@@ -36,5 +36,3 @@ module NetSuite
     end
   end
 end
-
-

--- a/lib/netsuite/records/currency_rate.rb
+++ b/lib/netsuite/records/currency_rate.rb
@@ -12,7 +12,7 @@ module NetSuite
 
       actions :get, :get_list, :search
 
-      fields :base_currency, :effective_date, :exchange_rate, :transaction_currency
+      fields :effective_date, :exchange_rate
 
       record_refs :base_currency, :transaction_currency
 

--- a/lib/netsuite/records/estimate.rb
+++ b/lib/netsuite/records/estimate.rb
@@ -10,12 +10,12 @@ module NetSuite
       actions :get, :get_list, :add, :initialize, :delete, :update, :upsert, :search
 
       fields :alt_handling_cost, :alt_sales_total, :alt_shipping_cost, :balance,
-        :bill_address, :billing_address, :billing_schedule, :bill_is_residential,
+        :bill_address, :billing_schedule, :bill_is_residential,
         :created_date, :currency_name, :discount_rate, :email, :end_date,
         :est_gross_profit, :exchange_rate, :handling_cost, :handling_tax1_rate, :is_taxable,
-        :last_modified_date, :memo, :message, :other_ref_num, :ship_date, :shipping_cost, 
-        :shipping_tax1_rate, :source, :start_date, :status, :sync_partner_teams, :sync_sales_teams, 
-        :to_be_emailed, :to_be_faxed, :to_be_printed, :total_cost_estimate, :tran_date, :tran_id, 
+        :last_modified_date, :memo, :message, :other_ref_num, :ship_date, :shipping_cost,
+        :shipping_tax1_rate, :source, :start_date, :status, :sync_partner_teams, :sync_sales_teams,
+        :to_be_emailed, :to_be_faxed, :to_be_printed, :total_cost_estimate, :tran_date, :tran_id,
         :linked_tracking_numbers, :is_multi_ship_to
 
       field :shipping_address, Address
@@ -24,8 +24,8 @@ module NetSuite
       field :item_list,                   EstimateItemList
       field :custom_field_list,           CustomFieldList
 
-      record_refs :bill_address_list, :created_from, :currency, :custom_form, :department, :discount_item, :entity, 
-        :handling_tax_code, :job, :klass, :lead_source, :location, :message_sel, :opportunity, :partner, 
+      record_refs :bill_address_list, :created_from, :currency, :custom_form, :department, :discount_item, :entity,
+        :handling_tax_code, :job, :klass, :lead_source, :location, :message_sel, :opportunity, :partner,
         :promo_code, :sales_group, :sales_rep, :ship_method, :shipping_tax_code, :subsidiary, :terms
 
       attr_reader :internal_id

--- a/lib/netsuite/records/invoice.rb
+++ b/lib/netsuite/records/invoice.rb
@@ -11,8 +11,8 @@ module NetSuite
 
       actions :get, :get_deleted, :get_list, :initialize, :add, :update, :delete, :upsert, :upsert_list, :search
 
-      fields :balance, :bill_address,
-        :billing_schedule, :contrib_pct, :created_date, :currency_name, :custom_field_list,
+      fields :balance,
+        :billing_schedule, :contrib_pct, :created_date, :currency_name,
         :deferred_revenue, :discount_amount, :discount_date, :discount_rate,
         :due_date, :email, :end_date, :est_gross_profit, :est_gross_profit_percent, :exchange_rate,
         :exclude_commission, :exp_cost_disc_amount, :exp_cost_disc_print, :exp_cost_disc_rate, :exp_cost_disc_tax_1_amt,
@@ -24,13 +24,13 @@ module NetSuite
         :linked_tracking_numbers, :memo, :message, :message_sel, :on_credit_hold, :opportunity,
         :other_ref_num, :partners_list, :rev_rec_end_date,
         :rev_rec_on_rev_commitment, :rev_rec_schedule, :rev_rec_start_date, :revenue_status, :sales_effective_date,
-        :sales_group, :sales_team_list, :ship_address, :ship_date, :ship_group_list,
+        :sales_group, :sales_team_list, :ship_date, :ship_group_list,
         :shipping_cost, :shipping_tax_1_rate, :shipping_tax_2_rate, :shipping_tax_code, :source, :start_date,
         :status, :sync_partner_teams, :sync_sales_teams, :tax_2_total,
         :tax_total, :time_disc_amount, :time_disc_print, :time_disc_rate, :time_disc_tax_1_amt, :time_disc_taxable,
         :time_discount, :time_list, :time_tax_code, :time_tax_rate_1, :time_tax_rate_2, :to_be_emailed, :to_be_faxed,
         :to_be_printed, :total_cost_estimate, :tracking_numbers, :tran_date, :tran_id, :tran_is_vsoe_bundle,
-        :transaction_bill_address, :transaction_ship_address, :vat_reg_num, :vsoe_auto_calc, :tax_rate
+        :vat_reg_num, :vsoe_auto_calc, :tax_rate
 
       field :transaction_bill_address, BillAddress
       field :transaction_ship_address, ShipAddress
@@ -39,7 +39,7 @@ module NetSuite
       field :shipping_address,         Address
       field :billing_address,          Address
 
-      read_only_fields :sub_total, :discount_total, :total, :recognized_revenue, :amount_remaining, :amount_paid, :amount,
+      read_only_fields :sub_total, :discount_total, :total, :recognized_revenue, :amount_remaining, :amount_paid,
                        :alt_shipping_cost, :gift_cert_applied, :handling_cost, :alt_handling_cost
 
       # https://system.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2020_2/schema/search/transactionsearchrowbasic.html?mode=package

--- a/lib/netsuite/records/invoice_item.rb
+++ b/lib/netsuite/records/invoice_item.rb
@@ -9,7 +9,7 @@ module NetSuite
       fields :amount, :amount_ordered, :bin_numbers, :cost_estimate, :cost_estimate_type, :current_percent,
         :defer_rev_rec, :description, :gift_cert_from, :gift_cert_message, :gift_cert_number, :gift_cert_recipient_email,
         :gift_cert_recipient_name, :gross_amt, :inventory_detail, :is_taxable, :item_is_fulfilled, :license_code, :line,
-        :klass, :options, :order_line, :percent_complete, :quantity, :quantity_available, :quantity_fulfilled,
+        :options, :order_line, :percent_complete, :quantity, :quantity_available, :quantity_fulfilled,
         :quantity_on_hand, :quantity_ordered, :rate, :rev_rec_end_date, :rev_rec_start_date,
         :serial_numbers, :ship_group, :tax1_amt, :tax_rate1, :tax_rate2, :vsoe_allocation, :vsoe_amount, :vsoe_deferral,
         :vsoe_delivered, :vsoe_permit_discount, :vsoe_price

--- a/lib/netsuite/records/item_fulfillment_item.rb
+++ b/lib/netsuite/records/item_fulfillment_item.rb
@@ -9,7 +9,7 @@ module NetSuite
 	      fields :amount, :amount_ordered, :bin_numbers, :cost_estimate, :cost_estimate_type, :current_percent,
 	        :defer_rev_rec, :description, :gift_cert_from, :gift_cert_message, :gift_cert_number, :gift_cert_recipient_email,
 	        :gift_cert_recipient_name, :gross_amt, :inventory_detail, :is_taxable, :item_is_fulfilled, :license_code, :line,
-	        :klass, :options, :order_line, :percent_complete, :quantity, :quantity_available, :quantity_fulfilled,
+	        :options, :order_line, :percent_complete, :quantity, :quantity_available, :quantity_fulfilled,
 	        :quantity_on_hand, :quantity_ordered, :rate, :rev_rec_end_date, :rev_rec_start_date,
 	        :serial_numbers, :ship_group, :tax1_amt, :tax_rate1, :tax_rate2, :vsoe_allocation, :vsoe_amount, :vsoe_deferral,
 	        :vsoe_delivered, :vsoe_permit_discount, :vsoe_price, :item_receive

--- a/lib/netsuite/records/item_receipt_item.rb
+++ b/lib/netsuite/records/item_receipt_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Namespaces::TranPurch
 
       fields :bin_numbers, :currency, :description, :expiration_date, :is_drop_shipment,
-             :item_name, :item_receive, :job_name, :line, :on_hand, :options, :order_line,
+             :item_name, :item_receive, :job_name, :line, :on_hand, :order_line,
              :quantity, :quantity_remaining, :rate, :restock, :serial_numbers,
              :unit_cost_override, :units_display
 

--- a/lib/netsuite/records/member_list.rb
+++ b/lib/netsuite/records/member_list.rb
@@ -3,8 +3,6 @@ module NetSuite
     class MemberList < Support::Sublist
       include Namespaces::ListAcct
 
-      fields :replace_all
-
       sublist :item_member, ItemMember
 
     end

--- a/lib/netsuite/records/non_inventory_purchase_item.rb
+++ b/lib/netsuite/records/non_inventory_purchase_item.rb
@@ -17,7 +17,7 @@ module NetSuite
         :manufacturer_zip, :matrix_option_list, :matrix_type, :max_donation_amount, :meta_tag_html, :minimum_quantity,
         :minimum_quantity_units, :mpn, :mult_manufacture_addr, :nex_tag_category, :no_price_message, :offer_support,
         :on_special, :out_of_stock_behavior, :out_of_stock_message, :overall_quantity_pricing_type, :page_title,
-        :preference_criterion, :presentation_item_list, :prices_include_tax, :pricing_matrix, :producer, :product_feed_list,
+        :preference_criterion, :presentation_item_list, :prices_include_tax, :producer, :product_feed_list,
         :rate, :related_items_description, :sales_description, :schedule_b_code, :schedule_b_number, :schedule_b_quantity,
         :search_keywords, :ship_individually, :shipping_cost, :shipping_cost_units, :shopping_dot_com_category,
         :shopzilla_category_id, :show_default_donation_amount, :site_category_list, :sitemap_priority, :soft_descriptor,

--- a/lib/netsuite/records/non_inventory_resale_item.rb
+++ b/lib/netsuite/records/non_inventory_resale_item.rb
@@ -17,7 +17,7 @@ module NetSuite
         :manufacturer_zip, :matrix_option_list, :matrix_type, :max_donation_amount, :meta_tag_html, :minimum_quantity,
         :minimum_quantity_units, :mpn, :mult_manufacture_addr, :nex_tag_category, :no_price_message, :offer_support,
         :on_special, :out_of_stock_behavior, :out_of_stock_message, :overall_quantity_pricing_type, :page_title,
-        :preference_criterion, :presentation_item_list, :prices_include_tax, :pricing_matrix, :producer, :product_feed_list,
+        :preference_criterion, :presentation_item_list, :prices_include_tax, :producer, :product_feed_list,
         :rate, :related_items_description, :sales_description, :schedule_b_code, :schedule_b_number, :schedule_b_quantity,
         :search_keywords, :ship_individually, :shipping_cost, :shipping_cost_units, :shopping_dot_com_category,
         :shopzilla_category_id, :show_default_donation_amount, :site_category_list, :sitemap_priority, :soft_descriptor,

--- a/lib/netsuite/records/non_inventory_sale_item.rb
+++ b/lib/netsuite/records/non_inventory_sale_item.rb
@@ -17,7 +17,7 @@ module NetSuite
         :manufacturer_zip, :matrix_option_list, :matrix_type, :max_donation_amount, :meta_tag_html, :minimum_quantity,
         :minimum_quantity_units, :mpn, :mult_manufacture_addr, :nex_tag_category, :no_price_message, :offer_support,
         :on_special, :out_of_stock_behavior, :out_of_stock_message, :overall_quantity_pricing_type, :page_title,
-        :preference_criterion, :presentation_item_list, :prices_include_tax, :pricing_matrix, :producer, :product_feed_list,
+        :preference_criterion, :presentation_item_list, :prices_include_tax, :producer, :product_feed_list,
         :rate, :related_items_description, :sales_description, :schedule_b_code, :schedule_b_number, :schedule_b_quantity,
         :search_keywords, :ship_individually, :shipping_cost, :shipping_cost_units, :shopping_dot_com_category,
         :shopzilla_category_id, :show_default_donation_amount, :site_category_list, :sitemap_priority, :soft_descriptor,

--- a/lib/netsuite/records/opportunity.rb
+++ b/lib/netsuite/records/opportunity.rb
@@ -17,7 +17,7 @@ module NetSuite
         :memo, :probability, :proj_alt_sales_amt, :projected_total,
         :range_high, :range_low,
         :ship_is_residential, :source, :status, :sync_partner_teams, :sync_sales_teams,
-        :tax2_total, :tax_total, :title, :total_cost_estimate, :tran_date, :tran_id,
+        :tax2_total, :title, :total_cost_estimate, :tran_date, :tran_id,
         :vat_reg_num, :weighted_total
 
       field :ship_address, ShipAddress

--- a/lib/netsuite/records/phone_call.rb
+++ b/lib/netsuite/records/phone_call.rb
@@ -10,7 +10,7 @@ module NetSuite
       actions :get, :get_list, :add, :delete, :update, :upsert
 
       fields :title, :message, :phone, :status, :priority, :start_date, :end_date,
-        :start_time, :end_time, :completed_date, :timed_event, :access_level, :timed_event
+        :start_time, :end_time, :completed_date, :timed_event, :access_level
 
       field :contact_list, ContactList
 

--- a/lib/netsuite/records/serialized_assembly_item.rb
+++ b/lib/netsuite/records/serialized_assembly_item.rb
@@ -180,7 +180,6 @@ module NetSuite
         :store_display_name,
         :store_display_thumbnail,
         :store_item_template,
-        :subsidiary_list,
         :supply_lot_sizing_method,
         :supply_replenishment_method,
         :supply_time_fence,

--- a/lib/netsuite/records/service_resale_item.rb
+++ b/lib/netsuite/records/service_resale_item.rb
@@ -15,7 +15,7 @@ module NetSuite
         :item_id, :last_modified_date, :matrix_option_list, :matrix_type, :max_donation_amount, :meta_tag_html,
         :minimum_quantity, :minimum_quantity_units, :no_price_message, :offer_support, :on_special, :out_of_stock_behavior,
         :out_of_stock_message, :overall_quantity_pricing_type, :page_title, :presentation_item_list, :prices_include_tax,
-        :pricing_matrix, :rate, :related_items_description, :sales_description, :search_keywords,
+        :rate, :related_items_description, :sales_description, :search_keywords,
         :show_default_donation_amount, :site_category_list, :sitemap_priority, :soft_descriptor, :specials_description,
         :store_description, :store_detailed_description, :store_display_name, :translations_list, :upc_code, :url_component,
         :use_marginal_rates, :vsoe_deferral, :vsoe_delivered, :vsoe_permit_discount, :vsoe_price, :vsoe_sop_group

--- a/lib/netsuite/records/service_sale_item.rb
+++ b/lib/netsuite/records/service_sale_item.rb
@@ -15,7 +15,7 @@ module NetSuite
         :item_id, :last_modified_date, :matrix_option_list, :matrix_type, :max_donation_amount, :meta_tag_html,
         :minimum_quantity, :minimum_quantity_units, :no_price_message, :offer_support, :on_special, :out_of_stock_behavior,
         :out_of_stock_message, :overall_quantity_pricing_type, :page_title, :presentation_item_list, :prices_include_tax,
-        :pricing_matrix, :rate, :related_items_description, :sales_description, :search_keywords,
+        :rate, :related_items_description, :sales_description, :search_keywords,
         :show_default_donation_amount, :site_category_list, :sitemap_priority, :soft_descriptor, :specials_description,
         :store_description, :store_detailed_description, :store_display_name, :translations_list, :upc_code, :url_component,
         :use_marginal_rates, :vsoe_deferral, :vsoe_delivered, :vsoe_permit_discount, :vsoe_price, :vsoe_sop_group

--- a/lib/netsuite/records/transfer_order_item.rb
+++ b/lib/netsuite/records/transfer_order_item.rb
@@ -8,7 +8,7 @@ module NetSuite
 
       fields :amount, :average_cost, :klass, :commit_inventory, :description,
              :expected_receipt_date, :expected_ship_date, :inventory_detail, :is_closed, :last_purchase_price,
-             :line, :options, :order_priority, :quantity, :quantity_available,
+             :line, :order_priority, :quantity, :quantity_available,
              :quantity_back_ordered, :quantity_committed, :quantity_fulfilled,
              :quantity_on_hand, :quantity_packed, :quantity_picked, :quantity_received,
              :rate, :serial_numbers

--- a/lib/netsuite/records/vendor.rb
+++ b/lib/netsuite/records/vendor.rb
@@ -9,16 +9,16 @@ module NetSuite
 
       actions :get, :get_list, :add, :update, :upsert, :delete, :search
 
-      fields :account_number, :alt_email, :alt_name, :alt_phone, :balance,
-             :balance_primary, :bcn, :bill_pay, :comments, :company_name, :credit_limit,
+      fields :account_number, :alt_email, :alt_name, :alt_phone,
+             :bcn, :bill_pay, :comments, :company_name, :credit_limit,
              :date_created, :default_address, :eligible_for_commission,
              :email, :email_preference, :email_transactions, :entity_id, :fax, :fax_transactions,
              :first_name, :give_access, :global_subscription_status, :home_phone, :is1099_eligible,
              :is_accountant, :is_inactive, :is_job_resource_vend, :is_person, :labor_cost,
-             :last_modified_date, :last_name, :legal_name, :middle_name, :mobile_phone, :opening_balance,
+             :last_name, :legal_name, :middle_name, :mobile_phone, :opening_balance,
              :opening_balance_date, :password, :password2, :phone, :phonetic_name, :pricing_schedule_list,
              :print_on_check_as, :print_transactions, :require_pwd_change, :roles_list, :salutation,
-             :send_email, :subscriptions_list, :tax_id_num, :title, :unbilled_orders, :unbilled_orders_primary,
+             :send_email, :subscriptions_list, :tax_id_num, :title,
              :url, :vat_reg_number
 
       field :custom_field_list, CustomFieldList

--- a/lib/netsuite/support/fields.rb
+++ b/lib/netsuite/support/fields.rb
@@ -21,6 +21,7 @@ module NetSuite
 
         def field(name, klass = nil)
           name_sym = name.to_sym
+          raise "#{name} already defined on #{self.name}" if fields.include?(name_sym)
           fields << name_sym
           if klass
             define_method(name_sym) do

--- a/spec/netsuite/support/fields_spec.rb
+++ b/spec/netsuite/support/fields_spec.rb
@@ -57,4 +57,30 @@ describe NetSuite::Support::Fields do
     end
   end
 
+  describe '.search_only_fields' do
+    context 'with arguments' do
+      it 'calls .search_only_field with each argument passed to it' do
+        [:one, :two, :three].each do |field|
+          expect(klass).to receive(:search_only_field).with(field)
+        end
+        klass.search_only_fields(:one, :two, :three)
+      end
+    end
+
+    context 'without arguments' do
+      it 'returns a Set of the search_only_field arguments' do
+        arguments = [:one, :two, :three]
+        klass.search_only_fields(*arguments)
+        expect(klass.search_only_fields).to eql(Set.new(arguments))
+      end
+    end
+  end
+
+  describe '.search_only_field' do
+    it 'defines instance accessor methods for the given field' do
+      expect(klass).to receive(:field).with(:one)
+      klass.search_only_field(:one)
+    end
+  end
+
 end

--- a/spec/netsuite/support/fields_spec.rb
+++ b/spec/netsuite/support/fields_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 
 describe NetSuite::Support::Fields do
-  let(:klass) { Class.new.send(:include, NetSuite::Support::Fields) }
+  DummyRecord = Class.new.send(:include, NetSuite::Support::Fields)
+  let(:klass) { DummyRecord }
   let(:instance) { klass.new }
+
+  before { klass.fields.clear }
 
   describe '.fields' do
     context 'with arguments' do
@@ -28,6 +31,12 @@ describe NetSuite::Support::Fields do
       klass.field(:one)
       instance.one = 1
       expect(instance.one).to eql(1)
+    end
+
+    it 'errors when already a field' do
+      klass.field :one
+
+      expect { klass.field :one }.to raise_error('one already defined on DummyRecord')
     end
   end
 


### PR DESCRIPTION
In adding the start of search_only_fields, a couple standard fields were mistakenly re-defined as search_only_fields, which ended up excluding. them when pushing data to NetSuite, under the guise they were search-only.

Now it's impossible to define the same field twice.

As a result, had to fix a number of occurrences of fields repeated between `fields` and another definition (ie `record_refs`, `read_only_fields`, `field`).

The only notable fix is on `Invoice`, where `bill_address` and `ship_address` were previously defined as `fields`, then got repeated as `search_only_fields`. In old APIs (<= 2014.1), these seemed to actually be fields, however in newer APIs (>= 2014.2), they no longer are. I'm erring on the side of newer APIs here, removing them as `fields` and leaving them as `search_only_fields`.

Fixed #486