### PR TITLE
Updates README.md to reflect task.refresh, not task.reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ task.update(message: 'New Message')
 task.delete
 
 # refresh/reload a record (helpful after adding the record for the first time)
-task.reload
+task.refresh
 
 # using get_select_value with a standard record
 NetSuite::Records::BaseRefList.get_select_value(


### PR DESCRIPTION
Couldn't figure out why .reload wasn't working, but it's because the method is called refresh, not reload.