### PR TITLE
fix incorrectly reference `:inventory_detail` to field instead of record_refs

### DIFF
--- a/lib/netsuite/records/item_receipt_item.rb
+++ b/lib/netsuite/records/item_receipt_item.rb
@@ -11,11 +11,12 @@ module NetSuite
              :quantity, :quantity_remaining, :rate, :restock, :serial_numbers,
              :unit_cost_override, :units_display
 
-      record_refs :bill_variance_status, :inventory_detail, :item, :landed_cost,
+      record_refs :bill_variance_status, :item, :landed_cost,
                   :location
 
       field :options, CustomFieldList
       field :custom_field_list, CustomFieldList
+      field :inventory_detail, InventoryDetail
 
       def initialize(attributes_or_record = {})
         case attributes_or_record


### PR DESCRIPTION
Hi,
I’m trying to create ItemReceipt against a LotNumberedInventoryItem, but it looks like the XML generated by the gem is using the wrong message.
Here is the generated XML


```xml
<env:Body>
    <platformMsgs:add>
      <platformMsgs:record xsi:type="tranPurch:ItemReceipt">
        <tranPurch:createdFrom externalId="38" type="purchaseOrder" />
        <tranPurch:itemList>
          <tranPurch:item>
            <tranPurch:item externalId="389263" />
            <tranPurch:itemReceive>true</tranPurch:itemReceive>
            <tranPurch:location externalId="23" />
            <tranPurch:quantity>10</tranPurch:quantity>
            <tranPurch:orderLine>1</tranPurch:orderLine>
            <tranPurch:inventoryDetail>
              <platformCore:inventoryAssignmentList>
                <platformMsgs:inventoryAssignment>
                  <platformMsgs:quantity>10</platformMsgs:quantity>
                  <platformMsgs:receiptInventoryNumber>DUMMY-LOT</platformMsgs:receiptInventoryNumber>
                </platformMsgs:inventoryAssignment>
              </platformCore:inventoryAssignmentList>
            </tranPurch:inventoryDetail>
          </tranPurch:item>
        </tranPurch:itemList>
        <tranPurch:tranDate>2021-09-28T15:28:45+02:00</tranPurch:tranDate>
        <tranPurch:customFieldList>
          <platformCore:customField xsi:type="platformCore:StringCustomFieldRef" scriptId="custbody_bbl_receipt_transaction_id">
            <platformCore:value>transaction_id</platformCore:value>
          </platformCore:customField>
        </tranPurch:customFieldList>
      </platformMsgs:record>
    </platformMsgs:add>
  </env:Body>
```

but here is a correct one

```xml
<env:Body>
    <platformMsgs:add>
      <platformMsgs:record xsi:type="tranPurch:ItemReceipt">
        <tranPurch:createdFrom externalId="38" type="purchaseOrder" />
        <tranPurch:itemList>
          <tranPurch:item>
            <tranPurch:item externalId="389263" />
            <tranPurch:itemReceive>true</tranPurch:itemReceive>
            <tranPurch:location externalId="23" />
            <tranPurch:quantity>10</tranPurch:quantity>
            <tranPurch:orderLine>1</tranPurch:orderLine>
            <tranPurch:inventoryDetail>
              <platformCommon:inventoryAssignmentList>
                <platformCommon:inventoryAssignment>
                  <platformCommon:quantity>10</platformCommon:quantity>
                  <platformCommon:receiptInventoryNumber>DUMMY-LOT</platformCommon:receiptInventoryNumber>
                </platformCommon:inventoryAssignment>
              </platformCommon:inventoryAssignmentList>
            </tranPurch:inventoryDetail>
          </tranPurch:item>
        </tranPurch:itemList>
        <tranPurch:tranDate>2021-09-28T15:28:45+02:00</tranPurch:tranDate>
        <tranPurch:customFieldList>
          <platformCore:customField xsi:type="platformCore:StringCustomFieldRef" scriptId="custbody_bbl_receipt_transaction_id">
            <platformCore:value>transaction_id</platformCore:value>
          </platformCore:customField>
        </tranPurch:customFieldList>
      </platformMsgs:record>
    </platformMsgs:add>
  </env:Body>
```

Note the difference, for the tranPurch:inventoryDetail the API is expecting <platformCommon:inventoryAssignmentList>not a  <platformCore:inventoryAssignmentList>

slack chat https://suitechat.slack.com/archives/C0HHV04FQ/p1632836785023200