### PR TITLE
Updating necessary Savon version

### DIFF
--- a/netsuite.gemspec
+++ b/netsuite.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = NetSuite::VERSION
 
-  gem.add_dependency 'savon', '>= 2.3.0', '<= 2.11.1'
+  gem.add_dependency 'savon', '>= 2.3.0'
 
   gem.add_development_dependency 'rspec', '~> 3.10.0'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
Savon has released new versions that have fixed the bug that previously prevented us from upgrading beyond version 2.11.1. We now don't need that unnecessary restriction and can work with newer Savon versions including the latest of 2.12.1.