### PR TITLE
Implement MatrixOptionList#to_record

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 * Dependabot to CI
 * CI run for Ruby 3
 * Add CI run for an environment with and without `tzinfo` installed
+* Implement MatrixOptionList#to_record (#504)
 
 ### Fixed
 * Fix "undefined method `[]` for #<Nori::StringIOFile>" when adding File (#495)

--- a/lib/netsuite/records/matrix_option_list.rb
+++ b/lib/netsuite/records/matrix_option_list.rb
@@ -1,6 +1,8 @@
 module NetSuite
   module Records
     class MatrixOptionList
+      include Namespaces::ListAcct
+
       # Deals with both hash and arrays of attributes[:matrix_option_list]
       #
       # Hash:
@@ -49,6 +51,20 @@ module NetSuite
 
       def options
         @options ||= []
+      end
+
+      def to_record
+        {
+          "#{record_namespace}:matrixOption" => options.map do |option|
+            {
+              'platformCore:value' => {
+                '@internalId' => option.value_id,
+                '@typeId' => option.type_id,
+              },
+              '@scriptId' => option.script_id
+            }
+          end
+        }
       end
     end
   end

--- a/spec/netsuite/records/matrix_option_list_spec.rb
+++ b/spec/netsuite/records/matrix_option_list_spec.rb
@@ -4,6 +4,8 @@ require 'ostruct'
 module NetSuite
   module Records
     describe MatrixOptionList do
+      let(:list) { described_class.new }
+
       it "deals with hash properly" do
         hash = {:value=>{:@internal_id=>"1", :@type_id=>"36", :name=>"some value"}, :@script_id=>'cust_field_1'}
 
@@ -29,6 +31,30 @@ module NetSuite
         expect(option.type_id).to eq "28"
         expect(option.name).to eq "some value 28"
         expect(option.script_id).to eq "cust_field_28"
+      end
+
+      describe '#to_record' do
+        before do
+          list.options << OpenStruct.new(
+            type_id: 'TYPE',
+            value_id: 'VALUE',
+            script_id: 'SCRIPT',
+            name: 'NAME',
+          )
+        end
+
+        it 'can represent itself as a SOAP record' do
+          record = {
+            'listAcct:matrixOption' => [{
+              '@scriptId' => 'SCRIPT',
+              'platformCore:value' => {
+                '@internalId' => 'VALUE',
+                '@typeId' => 'TYPE',
+              },
+            }],
+          }
+          expect(list.to_record).to eql(record)
+        end
       end
     end
   end


### PR DESCRIPTION
When creating a matrix child item, you pass the matrix options, but
without #to_record, the right XML wasn't generated.