### PR TITLE
Move definition of `search_joins` attribute from records to search action

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,7 +15,7 @@
 
 ### Fixed
 * Fix "undefined method `[]` for #<Nori::StringIOFile>" when adding File (#495)
-*
+* Moved definition of `search_joins` attribute from records to search action. The attribute was removed for AssemblyComponent, SerializedInventoryItemLocation, and WorkOrderItem as they don't offer the search action. (#511)
 
 ## 0.8.10
 

--- a/lib/netsuite/actions/search.rb
+++ b/lib/netsuite/actions/search.rb
@@ -235,6 +235,8 @@ module NetSuite
       module Support
         def self.included(base)
           base.extend(ClassMethods)
+
+          attr_accessor :search_joins
         end
 
         module ClassMethods

--- a/lib/netsuite/records/account.rb
+++ b/lib/netsuite/records/account.rb
@@ -18,7 +18,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/accounting_period.rb
+++ b/lib/netsuite/records/accounting_period.rb
@@ -13,7 +13,7 @@ module NetSuite
       record_refs :parent
 
       attr_reader :internal_id
-      attr_accessor :external_id, :search_joins
+      attr_accessor :external_id
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/assembly_component.rb
+++ b/lib/netsuite/records/assembly_component.rb
@@ -15,7 +15,6 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)
@@ -25,4 +24,3 @@ module NetSuite
     end
   end
 end
-

--- a/lib/netsuite/records/assembly_item.rb
+++ b/lib/netsuite/records/assembly_item.rb
@@ -50,7 +50,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/assembly_unbuild.rb
+++ b/lib/netsuite/records/assembly_unbuild.rb
@@ -26,7 +26,6 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/cash_refund.rb
+++ b/lib/netsuite/records/cash_refund.rb
@@ -115,7 +115,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/cash_sale.rb
+++ b/lib/netsuite/records/cash_sale.rb
@@ -36,7 +36,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/contact.rb
+++ b/lib/netsuite/records/contact.rb
@@ -24,7 +24,6 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/credit_memo.rb
+++ b/lib/netsuite/records/credit_memo.rb
@@ -38,7 +38,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/currency_rate.rb
+++ b/lib/netsuite/records/currency_rate.rb
@@ -21,7 +21,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/custom_record.rb
+++ b/lib/netsuite/records/custom_record.rb
@@ -22,7 +22,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/customer.rb
+++ b/lib/netsuite/records/customer.rb
@@ -44,7 +44,6 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/customer_deposit.rb
+++ b/lib/netsuite/records/customer_deposit.rb
@@ -29,7 +29,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/customer_payment.rb
+++ b/lib/netsuite/records/customer_payment.rb
@@ -28,7 +28,6 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/customer_refund.rb
+++ b/lib/netsuite/records/customer_refund.rb
@@ -24,7 +24,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/deposit.rb
+++ b/lib/netsuite/records/deposit.rb
@@ -20,7 +20,6 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/deposit_application.rb
+++ b/lib/netsuite/records/deposit_application.rb
@@ -37,7 +37,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/estimate.rb
+++ b/lib/netsuite/records/estimate.rb
@@ -111,7 +111,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/inbound_shipment.rb
+++ b/lib/netsuite/records/inbound_shipment.rb
@@ -20,7 +20,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/inventory_item.rb
+++ b/lib/netsuite/records/inventory_item.rb
@@ -325,7 +325,7 @@ module NetSuite
       # TODO: :translations_list, TranslationList
 
       attr_reader :internal_id
-      attr_accessor :external_id, :search_joins
+      attr_accessor :external_id
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/inventory_number.rb
+++ b/lib/netsuite/records/inventory_number.rb
@@ -19,7 +19,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/invoice.rb
+++ b/lib/netsuite/records/invoice.rb
@@ -141,7 +141,6 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/item_fulfillment.rb
+++ b/lib/netsuite/records/item_fulfillment.rb
@@ -30,7 +30,6 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/item_receipt.rb
+++ b/lib/netsuite/records/item_receipt.rb
@@ -26,7 +26,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/job.rb
+++ b/lib/netsuite/records/job.rb
@@ -29,7 +29,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/location.rb
+++ b/lib/netsuite/records/location.rb
@@ -28,7 +28,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/lot_numbered_inventory_item.rb
+++ b/lib/netsuite/records/lot_numbered_inventory_item.rb
@@ -243,7 +243,7 @@ module NetSuite
             :weight_units
 
       attr_reader :internal_id
-      attr_accessor :external_id, :search_joins
+      attr_accessor :external_id
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/non_inventory_sale_item.rb
+++ b/lib/netsuite/records/non_inventory_sale_item.rb
@@ -150,7 +150,6 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/opportunity.rb
+++ b/lib/netsuite/records/opportunity.rb
@@ -33,7 +33,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/payroll_item.rb
+++ b/lib/netsuite/records/payroll_item.rb
@@ -17,7 +17,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/purchase_order.rb
+++ b/lib/netsuite/records/purchase_order.rb
@@ -31,7 +31,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/sales_order.rb
+++ b/lib/netsuite/records/sales_order.rb
@@ -43,7 +43,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/serialized_inventory_item_location.rb
+++ b/lib/netsuite/records/serialized_inventory_item_location.rb
@@ -24,7 +24,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/service_sale_item.rb
+++ b/lib/netsuite/records/service_sale_item.rb
@@ -34,7 +34,6 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/subsidiary.rb
+++ b/lib/netsuite/records/subsidiary.rb
@@ -27,7 +27,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/transfer_order.rb
+++ b/lib/netsuite/records/transfer_order.rb
@@ -24,7 +24,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/vendor.rb
+++ b/lib/netsuite/records/vendor.rb
@@ -35,7 +35,6 @@ module NetSuite
 
       attr_reader :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/vendor_bill.rb
+++ b/lib/netsuite/records/vendor_bill.rb
@@ -25,7 +25,6 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/work_order.rb
+++ b/lib/netsuite/records/work_order.rb
@@ -26,7 +26,6 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)

--- a/lib/netsuite/records/work_order_item.rb
+++ b/lib/netsuite/records/work_order_item.rb
@@ -19,7 +19,6 @@ module NetSuite
 
       attr_reader   :internal_id
       attr_accessor :external_id
-      attr_accessor :search_joins
 
       def initialize(attributes = {})
         @internal_id = attributes.delete(:internal_id) || attributes.delete(:@internal_id)


### PR DESCRIPTION
Previously it was up to each record to define this attribute, if it
offered the search action. This created scenarios where a record like [`Bin`](https://github.com/NetSweet/netsuite/blob/9f1000535d62045e1fcb6220192840c943eaba57/lib/netsuite/records/bin.rb)
offered the `search` action, but didn't define the `search_joins`
attribute and therefore searching bins would error:

```
undefined method `search_joins=' for #<NetSuite::Records::Bin:0x00007f8f32948bf8 @internal_id="1044", @external_id=nil, @attributes={:bin_number=>"WIP-Fabric"}> (NoMethodError)
```

due to `SearchResult` assuming the record had such an attribute:
https://github.com/NetSweet/netsuite/blob/9f1000535d62045e1fcb6220192840c943eaba57/lib/netsuite/support/search_result.rb#L112

Now adding the `search` action to a record automatically adds the
necessary `search_joins` attribute.

The attribute was previously defined on `AssemblyComponent`,
`SerializedInventoryItemLocation`, and `WorkOrderItem`, however none of
those support actions at all, let alone the `search` action. They're all
records for sublist items. I suspect the attribute was erroneously
introduced in the first place as a result of copy/pasting to create the
record.