### PR TITLE
Support translations records

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -285,6 +285,8 @@ module NetSuite
     autoload :TransferOrder,                    'netsuite/records/transfer_order'
     autoload :TransferOrderItemList,            'netsuite/records/transfer_order_item_list'
     autoload :TransferOrderItem,                'netsuite/records/transfer_order_item'
+    autoload :Translation,                      'netsuite/records/translation'
+    autoload :TranslationList,                  'netsuite/records/translation_list'
     autoload :UnitsType,                        'netsuite/records/units_type'
     autoload :UnitsTypeUomList,                 'netsuite/records/units_type_uom_list'
     autoload :UnitsTypeUom,                     'netsuite/records/units_type_uom'

--- a/lib/netsuite/records/custom_record.rb
+++ b/lib/netsuite/records/custom_record.rb
@@ -17,6 +17,7 @@ module NetSuite
         :show_last_modified, :show_notes, :show_owner, :show_owner_allow_change, :show_owner_on_list, :use_permissions
 
       field :custom_field_list, CustomFieldList
+      field :translations_list, TranslationList
 
       record_refs :custom_form, :owner, :rec_type, :parent
 

--- a/lib/netsuite/records/description_item.rb
+++ b/lib/netsuite/records/description_item.rb
@@ -15,7 +15,7 @@ module NetSuite
       
       field :custom_field_list, CustomFieldList
       field :subsidiary_list, RecordRefList
-      # TODO field :translations_list, TranslationList
+      field :translations_list, TranslationList
 
       attr_reader :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/inventory_item.rb
+++ b/lib/netsuite/records/inventory_item.rb
@@ -322,7 +322,7 @@ module NetSuite
       # TODO: :presentation_item_list, PresentationItemList
       # TODO: :product_feed_list, ProductFeedList
       # TODO: :site_category_list, SiteCategoryList
-      # TODO: :translations_list, TranslationList
+      field :translations_list, TranslationList
 
       attr_reader :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/item_group.rb
+++ b/lib/netsuite/records/item_group.rb
@@ -18,7 +18,7 @@ module NetSuite
       # TODO field :item_carrier, ShippingCarrier
       field :member_list, ItemMemberList
       field :subsidiary_list, RecordRefList
-      # TODO field :translations_list, TranslationList
+      field :translations_list, TranslationList
 
       attr_reader :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/kit_item.rb
+++ b/lib/netsuite/records/kit_item.rb
@@ -49,7 +49,7 @@ module NetSuite
       # field :product_feed_list, ProductFeedList
       # field :site_category_list, SiteCategoryList
       # field :sitemap_priority, SitemapPriority
-      # field :translations_list, TranslationList
+      field :translations_list, TranslationList
       # field :vsoe_deferral, VsoeDeferral
       # field :vsoe_permit_discount, VsoePermitDiscount
       # field :vsoe_sop_group, VsoeSopGroup

--- a/lib/netsuite/records/lot_numbered_inventory_item.rb
+++ b/lib/netsuite/records/lot_numbered_inventory_item.rb
@@ -25,7 +25,7 @@ module NetSuite
       # TODO: field :presentation_item_list, PresentationItemList
       # TODO: field :product_feed_list, ProductFeedList
       # TODO: field :site_category_list, SiteCategoryList
-      # TODO: field :translations_list, TranslationList
+      field :translations_list, TranslationList
 
       actions :get, :get_list, :add, :delete, :search, :update, :upsert, :update_list
 

--- a/lib/netsuite/records/non_inventory_resale_item.rb
+++ b/lib/netsuite/records/non_inventory_resale_item.rb
@@ -170,7 +170,7 @@ module NetSuite
       # TODO: field :presentation_item_list, PresentationItemList
       # TODO: field :product_feed_list, ProductFeedList
       # TODO: field :site_category_list, SiteCategoryList
-      # TODO: field :translations_list, TranslationList
+      field :translations_list, TranslationList
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/non_inventory_sale_item.rb
+++ b/lib/netsuite/records/non_inventory_sale_item.rb
@@ -146,7 +146,7 @@ module NetSuite
       # TODO: field :presentation_item_list, PresentationItemList
       # TODO: field :product_feed_list, ProductFeedList
       # TODO: field :site_category_list, SiteCategoryList
-      # TODO: field :translations_list, TranslationList
+      field :translations_list, TranslationList
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/other_charge_sale_item.rb
+++ b/lib/netsuite/records/other_charge_sale_item.rb
@@ -53,7 +53,7 @@ module NetSuite
 
       field :custom_field_list, CustomFieldList
       field :pricing_matrix, PricingMatrix
-      # :translations_list,
+      field :translations_list, TranslationList
       # :matrix_option_list,
       # :item_options_list
       field :subsidiary_list, RecordRefList

--- a/lib/netsuite/records/payment_item.rb
+++ b/lib/netsuite/records/payment_item.rb
@@ -17,7 +17,7 @@ module NetSuite
       field :subsidiary_list, RecordRefList
       
       # TODO custom records need to be implemented
-      # field :translations_list, TranslationList
+      field :translations_list, TranslationList
 
       attr_reader :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/serialized_inventory_item.rb
+++ b/lib/netsuite/records/serialized_inventory_item.rb
@@ -214,7 +214,7 @@ module NetSuite
       # site_category_list	SiteCategoryList
       # sitemap_priority	SitemapPriority
       # subsidiary_list	RecordRefList
-      # translations_list	TranslationList
+      field :translations_list, TranslationList
       # vsoe_deferral	VsoeDeferral
       # vsoe_permit_discount	VsoePermitDiscount
       # vsoe_sop_group	VsoeSopGroup

--- a/lib/netsuite/records/service_resale_item.rb
+++ b/lib/netsuite/records/service_resale_item.rb
@@ -134,7 +134,7 @@ module NetSuite
       # TODO: field :hierarchy_versions_list, ServiceResaleItemHierarchyVersionsList
       # TODO: field :presentation_item_list, PresentationItemList
       # TODO: field :site_category_list, SiteCategoryList
-      # TODO: field :translations_list, TranslationList
+      field :translations_list, TranslationList
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/subtotal_item.rb
+++ b/lib/netsuite/records/subtotal_item.rb
@@ -15,7 +15,7 @@ module NetSuite
       
       field :custom_field_list, CustomFieldList
       field :subsidiary_list, RecordRefList
-      # TODO field :translations_list, TranslationList
+      field :translations_list, TranslationList
 
       attr_reader :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/translation.rb
+++ b/lib/netsuite/records/translation.rb
@@ -1,0 +1,13 @@
+module NetSuite
+  module Records
+    class Translation
+      include Support::Fields
+      include Support::Records
+      include Namespaces::ListAcct
+
+      def initialize(attributes = {})
+        initialize_from_dynamic_attributes_hash(attributes)
+      end
+    end
+  end
+end

--- a/lib/netsuite/records/translation_list.rb
+++ b/lib/netsuite/records/translation_list.rb
@@ -1,0 +1,11 @@
+module NetSuite
+  module Records
+    class TranslationList < Support::Sublist
+      include NetSuite::Namespaces::ListAcct
+
+      sublist :translation, NetSuite::Records::Translation
+
+      alias translations translation
+    end
+  end
+end

--- a/lib/netsuite/support/attributes.rb
+++ b/lib/netsuite/support/attributes.rb
@@ -17,6 +17,14 @@ module NetSuite
         self.klass = attributes[:class] if attributes[:class]
       end
 
+      def initialize_from_dynamic_attributes_hash(attributes = {})
+        attributes.each do |k, v|
+          self.class.field(k) unless self.class.fields.include?(k)
+          send("#{k}=", v)
+        end
+        self.klass = attributes[:class] if attributes[:class]
+      end
+
     end
   end
 end

--- a/spec/netsuite/records/lot_numbered_inventory_item_spec.rb
+++ b/spec/netsuite/records/lot_numbered_inventory_item_spec.rb
@@ -176,6 +176,7 @@ describe NetSuite::Records::LotNumberedInventoryItem do
       matrix_option_list: NetSuite::Records::MatrixOptionList,
       pricing_matrix: NetSuite::Records::PricingMatrix,
       subsidiary_list: NetSuite::Records::RecordRefList,
+      translations_list: NetSuite::Records::TranslationList,
     }.each do |field, klass|
       expect(item).to have_field(field, klass)
     end

--- a/spec/netsuite/records/translation_list_spec.rb
+++ b/spec/netsuite/records/translation_list_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe NetSuite::Records::TranslationList do
+  let(:list) { NetSuite::Records::TranslationList.new }
+
+  it 'has a translations attribute' do
+    expect(list.translations).to be_kind_of(Array)
+  end
+
+  describe '#to_record' do
+    before do
+      list.translations << NetSuite::Records::Translation.new(
+        locale: '_englishUK',
+        language: 'English (UK)',
+        display_name: 'display name',
+        sales_description: 'sales description'
+      )
+    end
+
+    it 'can represent itself as a SOAP record' do
+      record = {
+        "listAcct:translation" => [
+          {
+            "listAcct:locale" => "_englishUK",
+            "listAcct:language" => "English (UK)",
+            "listAcct:displayName" => "display name",
+            "listAcct:salesDescription" => "sales description"
+          }
+        ]
+      }
+      expect(list.to_record).to eql(record)
+    end
+  end
+end

--- a/spec/netsuite/records/translation_spec.rb
+++ b/spec/netsuite/records/translation_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe NetSuite::Records::Translation do
+  # let(:translation) { NetSuite::Records::Translation.new(field_one: 'value one', field_two: 'value two', field_three: 'value three') }
+
+  it 'has dynamic fields' do
+    translation = NetSuite::Records::Translation.new(field_one: 'value one', field_two: 'value two', field_three: 'value three')
+    [
+      :field_one,
+      :field_two,
+      :field_three
+    ].each do |field|
+      expect(translation).to have_field(field)
+    end
+  end
+end


### PR DESCRIPTION
TL;DR -- This supports translations for records that have access to

---

This allow to get translations from objects. Here is an example of translation that can be found in an item:
```xml
 <listAcct:translationsList>
      <listAcct:translation>
        <listAcct:locale>_englishUK</listAcct:locale>
        <listAcct:language>English (UK)</listAcct:language>
        <listAcct:displayName>Display Name</listAcct:displayName>
        <listAcct:salesDescription>Sales description</listAcct:salesDescription>
      </listAcct:translation>
 </listAcct:translationsList>
```

As each record can have its own translation fields, the `Translation` records fields are generated dynamically.
