### PR TITLE
Consider externalId in search criteria when using RecordRef as value

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -17,6 +17,7 @@
 ### Fixed
 * Fix "undefined method `[]` for #<Nori::StringIOFile>" when adding File (#495)
 * Moved definition of `search_joins` attribute from records to search action. The attribute was removed for AssemblyComponent, SerializedInventoryItemLocation, and WorkOrderItem as they don't offer the search action. (#511)
+* Consider externalId in search criteria when using RecordRef as value (#517)
 
 ## 0.8.10
 

--- a/lib/netsuite/actions/search.rb
+++ b/lib/netsuite/actions/search.rb
@@ -144,12 +144,23 @@ module NetSuite
                 h[element_name] = {
                   '@operator' => condition[:operator],
                   '@xsi:type' => 'platformCore:SearchMultiSelectField',
-                  "platformCore:searchValue" => {
-                    :content! => condition[:value].map(&:to_record),
-                    '@internalId' => condition[:value].map(&:internal_id),
-                    '@xsi:type' => 'platformCore:RecordRef',
-                    '@type' => 'account'
-                  }
+                  "platformCore:searchValue" => condition[:value].map do |value|
+                    search_value = {
+                      :content! => value.to_record,
+                      '@xsi:type' => 'platformCore:RecordRef',
+                      '@type' => 'account'
+                    }
+
+                    if value.internal_id
+                      search_value['@internalId'] = value.internal_id
+                    end
+
+                    if value.external_id
+                      search_value['@externalId'] = value.external_id
+                    end
+
+                    search_value
+                  end
                 }
               elsif condition[:value].is_a?(Array) && condition[:type] == 'SearchDateField'
                 # date ranges are handled via searchValue (start range) and searchValue2 (end range)

--- a/spec/netsuite/actions/search_spec.rb
+++ b/spec/netsuite/actions/search_spec.rb
@@ -201,6 +201,187 @@ describe NetSuite::Actions::Search do
   end
 
   context "basic search" do
+    it "should handle a basic search matching on RecordRef using internalId" do
+      response = File.read('spec/support/fixtures/search/basic_search_contact.xml')
+      savon.expects(:search)
+        .with(message: {
+          "searchRecord" => {
+            :content! => {
+              "listRel:basic" => {
+                "platformCommon:company" => {
+                  "@operator" => "anyOf",
+                  "@xsi:type" => "platformCore:SearchMultiSelectField",
+                  "platformCore:searchValue" => [
+                    {
+                      :content! => {},
+                      "@xsi:type" => "platformCore:RecordRef",
+                      "@type" => "account",
+                      "@internalId" => 7497,
+                    },
+                    {
+                      :content! => {},
+                      "@xsi:type" => "platformCore:RecordRef",
+                      "@type" => "account",
+                      "@internalId" => 7270,
+                    },
+                  ],
+                },
+              },
+            },
+            "@xsi:type" => "listRel:ContactSearch",
+          },
+        }).returns(response)
+
+      search = NetSuite::Records::Contact.search(
+        basic: [{
+          field: 'company',
+          operator: 'anyOf',
+          value: [
+            NetSuite::Records::RecordRef.new(internal_id: 7497),
+            NetSuite::Records::RecordRef.new(internal_id: 7270),
+          ],
+        }],
+      )
+
+      expect(search.results.size).to eq(1)
+    end
+
+    it "should handle a basic search matching on RecordRef using externalId" do
+      response = File.read('spec/support/fixtures/search/basic_search_contact.xml')
+      savon.expects(:search)
+        .with(message: {
+          "searchRecord" => {
+            :content! => {
+              "listRel:basic" => {
+                "platformCommon:company" => {
+                  "@operator" => "anyOf",
+                  "@xsi:type" => "platformCore:SearchMultiSelectField",
+                  "platformCore:searchValue" => [
+                    {
+                      :content! => {},
+                      "@xsi:type" => "platformCore:RecordRef",
+                      "@type" => "account",
+                      "@externalId" => "external_abc",
+                    },
+                    {
+                      :content! => {},
+                      "@xsi:type" => "platformCore:RecordRef",
+                      "@type" => "account",
+                      "@externalId" => "external_xyz",
+                    },
+                  ],
+                },
+              },
+            },
+            "@xsi:type" => "listRel:ContactSearch",
+          },
+        }).returns(response)
+
+      search = NetSuite::Records::Contact.search(
+        basic: [{
+          field: 'company',
+          operator: 'anyOf',
+          value: [
+            NetSuite::Records::RecordRef.new(external_id: "external_abc"),
+            NetSuite::Records::RecordRef.new(external_id: "external_xyz"),
+          ],
+        }],
+      )
+
+      expect(search.results.size).to eq(1)
+    end
+
+    it "should handle a basic search matching on RecordRef using mix of internalId and externalId" do
+      response = File.read('spec/support/fixtures/search/basic_search_contact.xml')
+      savon.expects(:search)
+        .with(message: {
+          "searchRecord" => {
+            :content! => {
+              "listRel:basic" => {
+                "platformCommon:company" => {
+                  "@operator" => "anyOf",
+                  "@xsi:type" => "platformCore:SearchMultiSelectField",
+                  "platformCore:searchValue" => [
+                    {
+                      :content! => {},
+                      "@xsi:type" => "platformCore:RecordRef",
+                      "@type" => "account",
+                      "@internalId" => 7497,
+                    },
+                    {
+                      :content! => {},
+                      "@xsi:type" => "platformCore:RecordRef",
+                      "@type" => "account",
+                      "@externalId" => "external_xyz",
+                    },
+                  ],
+                },
+              },
+            },
+            "@xsi:type" => "listRel:ContactSearch",
+          },
+        }).returns(response)
+
+      search = NetSuite::Records::Contact.search(
+        basic: [{
+          field: 'company',
+          operator: 'anyOf',
+          value: [
+            NetSuite::Records::RecordRef.new(internal_id: 7497),
+            NetSuite::Records::RecordRef.new(external_id: "external_xyz"),
+          ],
+        }],
+      )
+
+      expect(search.results.size).to eq(1)
+    end
+
+    it "should handle a basic search matching on RecordRef using both internalId and externalId" do
+      response = File.read('spec/support/fixtures/search/basic_search_contact.xml')
+      savon.expects(:search)
+        .with(message: {
+          "searchRecord" => {
+            :content! => {
+              "listRel:basic" => {
+                "platformCommon:company" => {
+                  "@operator" => "anyOf",
+                  "@xsi:type" => "platformCore:SearchMultiSelectField",
+                  "platformCore:searchValue" => [
+                    {
+                      :content! => {},
+                      "@xsi:type" => "platformCore:RecordRef",
+                      "@type" => "account",
+                      "@internalId" => 7497,
+                      "@externalId" => "external_abc",
+                    },
+                    {
+                      :content! => {},
+                      "@xsi:type" => "platformCore:RecordRef",
+                      "@type" => "account",
+                      "@externalId" => 7270,
+                    },
+                  ],
+                },
+              },
+            },
+            "@xsi:type" => "listRel:ContactSearch",
+          },
+        }).returns(response)
+
+      search = NetSuite::Records::Contact.search(
+        basic: [{
+          field: 'company',
+          operator: 'anyOf',
+          value: [
+            NetSuite::Records::RecordRef.new(internal_id: 7497, external_id: "external_abc"),
+            NetSuite::Records::RecordRef.new(external_id: 7270),
+          ],
+        }],
+      )
+
+      expect(search.results.size).to eq(1)
+    end
+
     skip "should handle searching basic fields"
     skip "should handle searching with joined fields"
   end

--- a/spec/support/fixtures/search/basic_search_contact.xml
+++ b/spec/support/fixtures/search/basic_search_contact.xml
@@ -1,0 +1,39 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Header>
+    <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2020_2.platform.webservices.netsuite.com">
+      <platformMsgs:nsId>WEBSERVICES_123456</platformMsgs:nsId>
+    </platformMsgs:documentInfo>
+  </soapenv:Header>
+  <soapenv:Body>
+    <searchResponse xmlns="urn:messages_2020_2.platform.webservices.netsuite.com">
+      <platformCore:searchResult xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com">
+        <platformCore:status isSuccess="true"/>
+        <platformCore:totalRecords>1</platformCore:totalRecords>
+        <platformCore:pageSize>1000</platformCore:pageSize>
+        <platformCore:totalPages>1</platformCore:totalPages>
+        <platformCore:pageIndex>1</platformCore:pageIndex>
+        <platformCore:searchId>WEBSERVICES_123456</platformCore:searchId>
+        <platformCore:recordList>
+          <platformCore:record xmlns:listRel="urn:relationships_2020_2.lists.webservices.netsuite.com" internalId="7272" externalId="customer_contact_3338" xsi:type="listRel:Contact">
+            <listRel:entityId>Mary</listRel:entityId>
+            <listRel:company internalId="7270">
+              <platformCore:name>1357 What a Company</platformCore:name>
+            </listRel:company>
+            <listRel:title>President/CEO</listRel:title>
+            <listRel:phone>(123) 555-1234</listRel:phone>
+            <listRel:email>***FILTERED***</listRel:email>
+            <listRel:defaultAddress>123 Main St</listRel:defaultAddress>
+            <listRel:isPrivate>false</listRel:isPrivate>
+            <listRel:isInactive>false</listRel:isInactive>
+            <listRel:subsidiary internalId="1">
+              <platformCore:name>Awesome Company</platformCore:name>
+            </listRel:subsidiary>
+            <listRel:globalSubscriptionStatus>_softOptOut</listRel:globalSubscriptionStatus>
+            <listRel:dateCreated>2021-03-03T08:26:56.000-08:00</listRel:dateCreated>
+            <listRel:lastModifiedDate>2021-07-07T09:49:51.000-07:00</listRel:lastModifiedDate>
+          </platformCore:record>
+        </platformCore:recordList>
+      </platformCore:searchResult>
+    </searchResponse>
+  </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
Given a criteria like:
```ruby
{
  field: 'company',
  operator: 'anyOf',
  value: [
    NetSuite::Records::RecordRef.new(external_id: "abc"),
    NetSuite::Records::RecordRef.new(external_id: "xyz"),
  ],
}
```

The gem was never passing that external ID to NetSuite for the result,
so you'd get a `INVALID_KEY_OR_REF` error as the XML line ended up
looking like:
```xml
<platformCore:searchValue xsi:type="platformCore:RecordRef" type="account"/>
```

Compared to the same line if you defined your `RecordRef` with an
internal ID:
```xml
<platformCore:searchValue internalId="1" xsi:type="platformCore:RecordRef" type="account"/>
```

Now that we pass the external ID too, that same line looks like:
```xml
<platformCore:searchValue externalId="abc" xsi:type="platformCore:RecordRef" type="account"/>
```

If your `RecordRef` has both internal and external IDs, it seems safe to
pass both and NetSuite seems to treat the internal ID as superseding the
external ID.