### PR TITLE
Add support for NullFieldList (starting with credit memos and invoices)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+* Add NullFieldList record (to credit memos and invoices) (#529)
+
 ### Fixed
 
 ## 0.8.11

--- a/README.md
+++ b/README.md
@@ -284,6 +284,20 @@ NetSuite::Records::BaseRefList.get_select_value(
 )
 ```
 
+## Null Fields
+
+```ruby
+# updating a field on a record to be null
+invoice = NetSuite::Records::Invoice.get(12345)
+invoice.update(null_field_list: 'shipMethod')
+
+# updating multiple fields on a record to be null
+invoice.update(null_field_list: ['shipAddressList', 'shipMethod'])
+
+# updating a custom fields on a record to be null, using custom field ID
+invoice.update(null_field_list: 'custBody9')
+```
+
 ## Searching
 
 ```ruby
@@ -417,7 +431,7 @@ NetSuite::Records::SalesOrder.search({
       'platformCommon:internalId/' => {},
       'platformCommon:email/' => {},
       'platformCommon:tranDate/' => {},
-      # If you include columns that are only part of the *SearchRowBasic (ie. TransactionSearchRowBasic), 
+      # If you include columns that are only part of the *SearchRowBasic (ie. TransactionSearchRowBasic),
       # they'll be readable on the resulting record just like regular fields (my_record.close_date).
       'platformCommon:closeDate/' => {}
     ],

--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -225,6 +225,7 @@ module NetSuite
     autoload :NonInventoryResaleItem,           'netsuite/records/non_inventory_resale_item'
     autoload :Note,                             'netsuite/records/note'
     autoload :NoteType,                         'netsuite/records/note_type'
+    autoload :NullFieldList,                    'netsuite/records/null_field_list'
     autoload :Opportunity,                      'netsuite/records/opportunity'
     autoload :OpportunityItem,                  'netsuite/records/opportunity_item'
     autoload :OpportunityItemList,              'netsuite/records/opportunity_item_list'

--- a/lib/netsuite/records/credit_memo.rb
+++ b/lib/netsuite/records/credit_memo.rb
@@ -23,6 +23,7 @@ module NetSuite
       field :item_list,                CreditMemoItemList
       field :apply_list,               CreditMemoApplyList
       field :ship_group_list,          SalesOrderShipGroupList
+      field :null_field_list,          NullFieldList
 
       # field :bill_address_list,
       field :transaction_bill_address, BillAddress

--- a/lib/netsuite/records/invoice.rb
+++ b/lib/netsuite/records/invoice.rb
@@ -38,6 +38,7 @@ module NetSuite
       field :custom_field_list,        CustomFieldList
       field :shipping_address,         Address
       field :billing_address,          Address
+      field :null_field_list,          NullFieldList
 
       read_only_fields :sub_total, :discount_total, :total, :recognized_revenue, :amount_remaining, :amount_paid,
                        :alt_shipping_cost, :gift_cert_applied, :handling_cost, :alt_handling_cost

--- a/lib/netsuite/records/null_field_list.rb
+++ b/lib/netsuite/records/null_field_list.rb
@@ -1,0 +1,15 @@
+module NetSuite
+  module Records
+    class NullFieldList
+      include Support::Fields
+      include Support::Records
+      include Namespaces::PlatformCore
+
+      fields :name
+
+      def initialize(attributes = {})
+        initialize_from_attributes_hash(attributes)
+      end
+    end
+  end
+end

--- a/lib/netsuite/support/records.rb
+++ b/lib/netsuite/support/records.rb
@@ -6,7 +6,7 @@ module NetSuite
 
       def to_record
         attributes.reject { |k,v| self.class.read_only_fields.include?(k) || self.class.search_only_fields.include?(k) }.inject({}) do |hash, (k,v)|
-          kname = "#{record_namespace}:"
+          kname = "#{v.is_a?(NetSuite::Records::NullFieldList) ? v.record_namespace : record_namespace}:"
           kname += k == :klass ? 'class' : k.to_s.lower_camelcase
 
           to_attributes!(hash, kname, v)

--- a/spec/netsuite/records/credit_memo_spec.rb
+++ b/spec/netsuite/records/credit_memo_spec.rb
@@ -20,6 +20,20 @@ describe NetSuite::Records::CreditMemo do
     end
   end
 
+  it 'has all the right fields with specific classes' do
+    {
+      custom_field_list: NetSuite::Records::CustomFieldList,
+      item_list: NetSuite::Records::CreditMemoItemList,
+      apply_list: NetSuite::Records::CreditMemoApplyList,
+      ship_group_list: NetSuite::Records::SalesOrderShipGroupList,
+      null_field_list: NetSuite::Records::NullFieldList,
+      transaction_bill_address: NetSuite::Records::BillAddress,
+      billing_address: NetSuite::Records::Address,
+    }.each do |field, klass|
+      expect(memo).to have_field(field, klass)
+    end
+  end
+
   it 'has all the right record refs' do
     [
       :account, :bill_address_list, :created_from, :custom_form, :department, :discount_item, :entity, :gift_cert,

--- a/spec/netsuite/records/invoice_spec.rb
+++ b/spec/netsuite/records/invoice_spec.rb
@@ -32,6 +32,20 @@ describe NetSuite::Records::Invoice do
     end
   end
 
+  it 'has all the right fields with specific classes' do
+    {
+      transaction_bill_address: NetSuite::Records::BillAddress,
+      transaction_ship_address: NetSuite::Records::ShipAddress,
+      item_list: NetSuite::Records::InvoiceItemList,
+      custom_field_list: NetSuite::Records::CustomFieldList,
+      shipping_address: NetSuite::Records::Address,
+      billing_address: NetSuite::Records::Address,
+      null_field_list: NetSuite::Records::NullFieldList,
+    }.each do |field, klass|
+      expect(invoice).to have_field(field, klass)
+    end
+  end
+
   it 'has all the right read_only_fields' do
     [
       :sub_total, :discount_total, :total, :alt_handling_cost, :alt_shipping_cost, :gift_cert_applied,

--- a/spec/netsuite/records/null_field_list_spec.rb
+++ b/spec/netsuite/records/null_field_list_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe NetSuite::Records::RecordRef do
+  let(:null_field_list) { NetSuite::Records::NullFieldList.new }
+
+  describe '#to_record' do
+    it 'can represent itself as a SOAP record for single value' do
+      null_field_list.name = 'blah'
+      record = {
+        'platformCore:name' => 'blah'
+      }
+      expect(null_field_list.to_record).to eql(record)
+    end
+
+    it 'can represent itself as a SOAP record for multiple values' do
+      null_field_list.name = ['blah', 'foo']
+      record = {
+        'platformCore:name' => ['blah', 'foo']
+      }
+      expect(null_field_list.to_record).to eql(record)
+    end
+  end
+
+  describe '#record_type' do
+    it 'returns a string of the SOAP type' do
+      expect(null_field_list.record_type).to eql('platformCore:NullFieldList')
+    end
+  end
+
+end

--- a/spec/netsuite/support/records_spec.rb
+++ b/spec/netsuite/support/records_spec.rb
@@ -4,11 +4,14 @@ module Foo
   module Bar
     class Baz
       include NetSuite::Support::Fields
+      include NetSuite::Support::RecordRefs
       include NetSuite::Support::Records
+      include NetSuite::Namespaces::TranSales
 
-      def attributes
-        { :source => 'Google', :total => 100.0 }
-      end
+      fields :source, :total
+      field :null_field_list, NetSuite::Records::NullFieldList
+
+      record_ref :related_record
     end
   end
 end
@@ -16,18 +19,41 @@ end
 describe NetSuite::Support::Records do
   let(:instance) { Foo::Bar::Baz.new }
 
-  describe '#record_type' do
+  describe '#to_record' do
     it 'returns a hash of attributes to be used in a SOAP request' do
+      instance.source = 'Google'
+      instance.total = 100.0
+
       expect(instance.to_record).to eql({
-        'platformCore:source' => 'Google',
-        'platformCore:total'  => 100.0
+        'tranSales:source' => 'Google',
+        'tranSales:total'  => 100.0
+      })
+    end
+
+    it 'uses the records namespace for the outer elements namespace and the field values namespace for the inner elements namespace' do
+      instance.related_record = NetSuite::Records::RecordRef.new(name: 'blah')
+
+      expect(instance.to_record).to eq({
+        'tranSales:relatedRecord' => {
+          'platformCore:name' => 'blah',
+        },
+      })
+    end
+
+    it 'uses the fields namespace for the outer elements namespace for NullFieldList value' do
+      instance.null_field_list.name = 'source'
+
+      expect(instance.to_record).to eq({
+        'platformCore:nullFieldList' => {
+          'platformCore:name' => 'source',
+        },
       })
     end
   end
 
   describe '#record_type' do
     it 'returns a string of the record type to be used in a SOAP request' do
-      expect(instance.record_type).to eql('platformCore:Baz')
+      expect(instance.record_type).to eql('tranSales:Baz')
     end
   end
 


### PR DESCRIPTION
NullFieldList is used to either clear an existing value on update, or
avoid a default being applied on adding a record.

My use case only required support for credit memos and invoices, so I
started there, but this could likely be added to most records.

This was heavily inspired by @gmike11's work in #481, but that seems to
lump a bunch of changes together. This also solves #398.

Where #481 manipulated the XML request body to address that the
`<platformCore:nullFieldList>` needs to always use the `platformCore`
namespace, as opposed to the record's normal namespace (ie `transSale`
for invoice) as happens for any other field, I tried to address that on
the `#to_record` side.