### PR TITLE
Add `get_deleted` action to item records

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@
 ### Added
 
 * Add NullFieldList record (to credit memos and invoices) (#529)
+* Add `get_deleted` action to item records (#530)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -607,6 +607,53 @@ deposit.payment = 20
 deposit.add
 ```
 
+## Getting Deleted Records
+
+```ruby
+response = NetSuite::Records::LotNumberedInventoryItem.get_deleted({
+  criteria: [
+    {
+      # If you don't specify a type criteria, you'll get all deleted records,
+      # regardless of the type of record you called this on.
+      field: 'type',
+      operator: 'anyOf',
+      value: 'lotNumberedInventoryItem',
+    }
+  ],
+})
+
+Array(response.body.fetch(:deleted_record_list)).first
+# => {
+#      :deleted_date => Wed, 16 Feb 2022 17:43:45 -0800,
+#      :record => {
+#        :name => "My Item",
+#        :@internal_id => "12485",
+#        :@type => "lotNumberedInventoryItem",
+#        :"@xsi:type" => "platformCore:RecordRef"
+#      }
+#    }
+
+# deleted_record_list could be:
+#   nil - No records matching criteria were deleted
+#   Hash - A single record matching criteria was deleted
+#   Array - Multiple records matching criteria were deleted
+
+# Simple pagination
+page = 1
+begin
+  response = NetSuite::Records::LotNumberedInventoryItem.get_deleted({
+    criteria: [
+      # your criteria
+    ],
+    page: page,
+  })
+
+  # Do your thing with response.body.fetch(:deleted_record_list)
+
+  page += 1
+end until page > Integer(response.fetch(:total_pages))
+```
+
 ## Non-standard Operations
 
 ```ruby

--- a/lib/netsuite/records/assembly_item.rb
+++ b/lib/netsuite/records/assembly_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :get_select_value, :add, :delete, :update, :upsert, :upsert_list, :search
+      actions :get, :get_deleted, :get_list, :get_select_value, :add, :delete, :update, :upsert, :upsert_list, :search
 
       fields :auto_lead_time, :auto_preferred_stock_level, :auto_reorder_point, :available_to_partners, :average_cost, :build_entire_assembly,
         :copy_description, :cost, :cost_estimate, :cost_estimate_type, :cost_estimate_units, :cost_units, :costing_method,

--- a/lib/netsuite/records/description_item.rb
+++ b/lib/netsuite/records/description_item.rb
@@ -7,12 +7,12 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :delete, :search, :update, :upsert
+      actions :get, :get_deleted, :get_list, :add, :delete, :search, :update, :upsert
 
       fields  :available_to_partners, :created_date, :description, :display_name, :include_children, :is_inactive, :item_id, :last_modified_date
 
       record_refs :custom_form, :department, :issue_product, :klass, :location
-      
+
       field :custom_field_list, CustomFieldList
       field :subsidiary_list, RecordRefList
       field :translations_list, TranslationList

--- a/lib/netsuite/records/discount_item.rb
+++ b/lib/netsuite/records/discount_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :update, :delete, :search, :upsert
+      actions :get, :get_deleted, :get_list, :add, :update, :delete, :search, :upsert
 
       fields :available_to_partners, :created_date, :description, :display_name, :include_children, :is_inactive, :is_pre_tax,
         :item_id, :last_modified_date, :non_posting, :rate, :upc_code, :vendor_name

--- a/lib/netsuite/records/inventory_item.rb
+++ b/lib/netsuite/records/inventory_item.rb
@@ -20,7 +20,7 @@ module NetSuite
       #     }
       #  ]
       #
-      actions :get, :get_list, :add, :delete, :search, :update, :upsert, :update_list
+      actions :get, :get_deleted, :get_list, :add, :delete, :search, :update, :upsert, :update_list
 
       fields :auto_lead_time,
             :auto_preferred_stock_level,

--- a/lib/netsuite/records/item_group.rb
+++ b/lib/netsuite/records/item_group.rb
@@ -7,13 +7,13 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :delete, :search, :update, :upsert
+      actions :get, :get_deleted, :get_list, :add, :delete, :search, :update, :upsert
 
       fields :available_to_partners, :created_date, :description, :display_name, :include_children, :include_start_end_lines,
              :is_inactive, :is_vsoe_bundle, :item_id, :last_modified_date, :print_items, :upc_code, :vendor_name
 
       record_refs :custom_form, :default_item_ship_method, :department, :issue_product, :item_ship_method_list, :klass, :location, :parent
-      
+
       field :custom_field_list, CustomFieldList
       # TODO field :item_carrier, ShippingCarrier
       field :member_list, ItemMemberList

--- a/lib/netsuite/records/kit_item.rb
+++ b/lib/netsuite/records/kit_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :delete, :search, :update, :upsert
+      actions :get, :get_deleted, :get_list, :add, :delete, :search, :update, :upsert
 
       fields :available_to_partners, :cost_estimate, :created_date, :defer_rev_rec, :description, :display_name,
         :dont_show_price, :enforce_min_qty_internally, :exclude_from_sitemap, :featured_description, :handling_cost,

--- a/lib/netsuite/records/lot_numbered_assembly_item.rb
+++ b/lib/netsuite/records/lot_numbered_assembly_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :get_select_value, :add, :delete, :update, :upsert, :upsert_list, :search
+      actions :get, :get_deleted, :get_list, :get_select_value, :add, :delete, :update, :upsert, :upsert_list, :search
 
       fields :auto_lead_time, :auto_preferred_stock_level, :auto_reorder_point, :available_to_partners, :average_cost, :build_entire_assembly,
         :copy_description, :cost, :cost_estimate, :cost_estimate_type, :cost_estimate_units, :cost_units, :costing_method,

--- a/lib/netsuite/records/lot_numbered_inventory_item.rb
+++ b/lib/netsuite/records/lot_numbered_inventory_item.rb
@@ -27,7 +27,7 @@ module NetSuite
       # TODO: field :site_category_list, SiteCategoryList
       field :translations_list, TranslationList
 
-      actions :get, :get_list, :add, :delete, :search, :update, :upsert, :update_list
+      actions :get, :get_deleted, :get_list, :add, :delete, :search, :update, :upsert, :update_list
 
       record_refs :alternate_demand_source_item,
                   :asset_account,

--- a/lib/netsuite/records/non_inventory_purchase_item.rb
+++ b/lib/netsuite/records/non_inventory_purchase_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :delete, :search, :upsert
+      actions :get, :get_deleted, :get_list, :add, :delete, :search, :upsert
 
       fields :available_to_partners, :cost_estimate, :cost_estimate_type, :cost_estimate_units, :country_of_manufacture,
         :created_date, :display_name, :dont_show_price, :enforce_min_qty_internally, :exclude_from_sitemap,

--- a/lib/netsuite/records/non_inventory_resale_item.rb
+++ b/lib/netsuite/records/non_inventory_resale_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :delete, :search, :upsert, :update
+      actions :get, :get_deleted, :get_list, :add, :delete, :search, :upsert, :update
 
       fields :amortization_period,
             :available_to_partners,

--- a/lib/netsuite/records/non_inventory_sale_item.rb
+++ b/lib/netsuite/records/non_inventory_sale_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :delete, :search, :update, :upsert
+      actions :get, :get_deleted, :get_list, :add, :delete, :search, :update, :upsert
 
       fields :available_to_partners,
             :contingent_revenue_handling,

--- a/lib/netsuite/records/other_charge_sale_item.rb
+++ b/lib/netsuite/records/other_charge_sale_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :update, :delete, :upsert, :search
+      actions :get, :get_deleted, :get_list, :add, :update, :delete, :upsert, :search
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/lib/netsuite/records/payment_item.rb
+++ b/lib/netsuite/records/payment_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :delete, :search, :update, :upsert
+      actions :get, :get_deleted, :get_list, :add, :delete, :search, :update, :upsert
 
       fields :available_to_partners, :created_date, :description, :display_name, :include_children, :is_inactive, :item_id, :last_modified_date, :undep_funds
 
@@ -15,7 +15,7 @@ module NetSuite
 
       field :custom_field_list, CustomFieldList
       field :subsidiary_list, RecordRefList
-      
+
       # TODO custom records need to be implemented
       field :translations_list, TranslationList
 

--- a/lib/netsuite/records/serialized_assembly_item.rb
+++ b/lib/netsuite/records/serialized_assembly_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :delete, :search, :update, :upsert
+      actions :get, :get_deleted, :get_list, :add, :delete, :search, :update, :upsert
 
       fields :alternate_demand_source_item,
         :asset_account,

--- a/lib/netsuite/records/serialized_inventory_item.rb
+++ b/lib/netsuite/records/serialized_inventory_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :delete, :search, :update, :upsert
+      actions :get, :get_deleted, :get_list, :add, :delete, :search, :update, :upsert
 
       record_refs :soft_descriptor,
         :stock_unit,

--- a/lib/netsuite/records/service_resale_item.rb
+++ b/lib/netsuite/records/service_resale_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :update, :delete, :upsert, :search
+      actions :get, :get_deleted, :get_list, :add, :update, :delete, :upsert, :search
 
       fields :amortization_period,
             :available_to_partners,

--- a/lib/netsuite/records/service_sale_item.rb
+++ b/lib/netsuite/records/service_sale_item.rb
@@ -7,7 +7,7 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :update, :delete, :upsert, :search
+      actions :get, :get_deleted, :get_list, :add, :update, :delete, :upsert, :search
 
       fields :available_to_partners, :cost_estimate, :cost_estimate_type, :cost_estimate_units, :create_job, :created_date,
         :display_name, :dont_show_price, :enforce_min_qty_internally, :exclude_from_sitemap, :featured_description,

--- a/lib/netsuite/records/subtotal_item.rb
+++ b/lib/netsuite/records/subtotal_item.rb
@@ -7,12 +7,12 @@ module NetSuite
       include Support::Actions
       include Namespaces::ListAcct
 
-      actions :get, :get_list, :add, :delete, :search, :update, :upsert
+      actions :get, :get_deleted, :get_list, :add, :delete, :search, :update, :upsert
 
       fields :available_to_partners, :created_date, :description, :include_children, :is_inactive, :item_id, :last_modified_date
 
       record_refs :custom_form, :department, :issue_product, :klass, :location
-      
+
       field :custom_field_list, CustomFieldList
       field :subsidiary_list, RecordRefList
       field :translations_list, TranslationList
@@ -32,4 +32,3 @@ module NetSuite
     end
   end
 end
-		


### PR DESCRIPTION
I also added some documentation about how to use the action.

The documentation reveals a few rough parts around this action. Notably:

The response you get back is very raw, and not a typical record. Given
how little data is returned, I'm not sure if it'd be better to
instantiate a full record for consistency, or if there should be a
new `DeletedRecord`-style record, with a field for `deleted_date`
and a record_ref for `record`, making it a little easier to work with.

You have to paginate yourself. Eventually it'd be nice if something like
`SearchResult#results_in_batches` were offered to do it for you, though
that'd be a breaking change to the return value of the action currently.

The record class you call `get_deleted` on has no influence on the
request actually performed, so without any criteria, you'll get records
back that are totally unrelated to the record class it was called upon.
This goes beyond how search works where an inventory item search returns
all item types, this includes even non-items that were deleted. Perhaps
it'd be less surprising if the gem set a type criteria for you based on
the calling record type, though perhaps there's some value in the
current behavior of wanting to get all deleted records regardless of
type?