### PR TITLE
Remove monkey patched `lower_camelcase` method on String

### DIFF
--- a/lib/netsuite.rb
+++ b/lib/netsuite.rb
@@ -5,9 +5,9 @@ require 'netsuite/version'
 require 'netsuite/errors'
 require 'netsuite/utilities'
 require 'netsuite/utilities/data_center'
+require 'netsuite/utilities/strings'
 require 'netsuite/rest/utilities/roles'
 require 'netsuite/rest/utilities/request'
-require 'netsuite/core_ext/string/lower_camelcase'
 
 module NetSuite
   autoload :Configuration, 'netsuite/configuration'

--- a/lib/netsuite/actions/delete.rb
+++ b/lib/netsuite/actions/delete.rb
@@ -21,7 +21,7 @@ module NetSuite
       end
 
       def soap_type
-        @object.class.to_s.split('::').last.lower_camelcase
+        NetSuite::Support::Records.netsuite_type(@object)
       end
 
       # <soap:Body>

--- a/lib/netsuite/actions/delete_list.rb
+++ b/lib/netsuite/actions/delete_list.rb
@@ -40,7 +40,7 @@ module NetSuite
             }
           end
         else
-          type = @klass.to_s.split('::').last.lower_camelcase
+          type = NetSuite::Support::Records.netsuite_type(@klass)
           record_type = 'platformCore:RecordRef'
 
           list.map do |internal_id|

--- a/lib/netsuite/actions/get.rb
+++ b/lib/netsuite/actions/get.rb
@@ -21,7 +21,7 @@ module NetSuite
       end
 
       def soap_type
-        @klass.to_s.split('::').last.lower_camelcase
+        NetSuite::Support::Records.netsuite_type(@klass)
       end
 
       # <soap:Body>

--- a/lib/netsuite/actions/get_deleted.rb
+++ b/lib/netsuite/actions/get_deleted.rb
@@ -20,7 +20,7 @@ module NetSuite
       end
 
       def soap_type
-        @object.class.to_s.split('::').last.lower_camelcase
+        NetSuite::Support::Records.netsuite_type(@object)
       end
 
       # <soap:Body>

--- a/lib/netsuite/actions/get_list.rb
+++ b/lib/netsuite/actions/get_list.rb
@@ -33,7 +33,7 @@ module NetSuite
             }
           end
         else
-          type = @klass.to_s.split('::').last.lower_camelcase
+          type = NetSuite::Support::Records.netsuite_type(@klass)
           record_type = 'platformCore:RecordRef'
 
           list.map do |internal_id|

--- a/lib/netsuite/actions/initialize.rb
+++ b/lib/netsuite/actions/initialize.rb
@@ -28,12 +28,12 @@ module NetSuite
       def request_body
         {
           'platformMsgs:initializeRecord' => {
-            'platformCore:type'      => @klass.to_s.split('::').last.lower_camelcase,
+            'platformCore:type'      => NetSuite::Support::Records.netsuite_type(@klass),
             'platformCore:reference' => {},
             :attributes!             => {
               'platformCore:reference' => {
                 'internalId' => @object.internal_id,
-                :type        => @object.class.to_s.split('::').last.lower_camelcase
+                :type        => NetSuite::Support::Records.netsuite_type(@object)
               }
             }
           }

--- a/lib/netsuite/actions/search.rb
+++ b/lib/netsuite/actions/search.rb
@@ -26,7 +26,7 @@ module NetSuite
           .update(NetSuite::Configuration.soap_header)
           .merge(
             (@options.delete(:preferences) || {}).inject({'platformMsgs:SearchPreferences' => {}}) do |h, (k, v)|
-              h['platformMsgs:SearchPreferences'][k.to_s.lower_camelcase] = v
+              h['platformMsgs:SearchPreferences'][NetSuite::Utilities::Strings.lower_camelcase(k.to_s)] = v
               h
             end
           )

--- a/lib/netsuite/core_ext/string/lower_camelcase.rb
+++ b/lib/netsuite/core_ext/string/lower_camelcase.rb
@@ -1,9 +1,0 @@
-class String
-  def lower_camelcase
-    str = dup
-    str.gsub!(/\/(.?)/) { "::#{$1.upcase}" }
-    str.gsub!(/(?:_+|-+)([a-z]|[0-9])/) { $1.upcase }
-    str.gsub!(/(\A|\s)([A-Z])/) { $1 + $2.downcase }
-    str
-  end
-end

--- a/lib/netsuite/records/record_ref.rb
+++ b/lib/netsuite/records/record_ref.rb
@@ -21,7 +21,7 @@ module NetSuite
           record = attributes_or_record
           @internal_id = record.internal_id if record.respond_to?(:internal_id)
           @external_id = record.external_id if record.respond_to?(:external_id)
-          @type        = record.class.to_s.split('::').last.lower_camelcase
+          @type        = NetSuite::Support::Records.netsuite_type(record)
         end
       end
 

--- a/lib/netsuite/support/records.rb
+++ b/lib/netsuite/support/records.rb
@@ -7,7 +7,7 @@ module NetSuite
       def to_record
         attributes.reject { |k,v| self.class.read_only_fields.include?(k) || self.class.search_only_fields.include?(k) }.inject({}) do |hash, (k,v)|
           kname = "#{v.is_a?(NetSuite::Records::NullFieldList) ? v.record_namespace : record_namespace}:"
-          kname += k == :klass ? 'class' : k.to_s.lower_camelcase
+          kname += k == :klass ? 'class' : NetSuite::Utilities::Strings.lower_camelcase(k.to_s)
 
           to_attributes!(hash, kname, v)
 
@@ -38,13 +38,13 @@ module NetSuite
         if v.kind_of?(NetSuite::Records::RecordRef) && v.type
           hash[:attributes!] ||= {}
           hash[:attributes!][kname] ||= {}
-          hash[:attributes!][kname]['type'] = v.type.lower_camelcase
+          hash[:attributes!][kname]['type'] = NetSuite::Utilities::Strings.lower_camelcase(v.type)
         end
 
         if v.kind_of?(NetSuite::Records::CustomRecordRef) && v.type_id
           hash[:attributes!] ||= {}
           hash[:attributes!][kname] ||= {}
-          hash[:attributes!][kname]['typeId'] = v.type_id.lower_camelcase
+          hash[:attributes!][kname]['typeId'] = NetSuite::Utilities::Strings.lower_camelcase(v.type_id)
         end
       end
 
@@ -53,11 +53,11 @@ module NetSuite
       end
 
       def netsuite_type
-        record_type_without_namespace.lower_camelcase
+        Records.netsuite_type(self)
       end
 
       def record_type_without_namespace
-        "#{self.class.to_s.split('::').last}"
+        Records.record_type_without_namespace(self)
       end
 
       def refresh(credentials = {})
@@ -73,6 +73,15 @@ module NetSuite
         self.errors = nil
 
         self
+      end
+
+      def self.netsuite_type(obj)
+        NetSuite::Utilities::Strings.lower_camelcase(record_type_without_namespace(obj))
+      end
+
+      def self.record_type_without_namespace(obj)
+        klass = obj.is_a?(Class) ? obj : obj.class
+        "#{klass.to_s.split('::').last}"
       end
 
     end

--- a/lib/netsuite/support/sublist.rb
+++ b/lib/netsuite/support/sublist.rb
@@ -35,7 +35,7 @@ module NetSuite
       end
 
       def to_record
-        rec = { "#{record_namespace}:#{sublist_key.to_s.lower_camelcase}" => send(self.sublist_key).map(&:to_record) }
+        rec = { "#{record_namespace}:#{NetSuite::Utilities::Strings.lower_camelcase(sublist_key.to_s)}" => send(self.sublist_key).map(&:to_record) }
 
         if !replace_all.nil?
           rec["#{record_namespace}:replaceAll"] = !!replace_all

--- a/lib/netsuite/utilities/strings.rb
+++ b/lib/netsuite/utilities/strings.rb
@@ -1,0 +1,15 @@
+module NetSuite
+  module Utilities
+    module Strings
+      class << self
+        def lower_camelcase(obj)
+          str = obj.is_a?(String) ? obj.dup : obj.to_s
+          str.gsub!(/\/(.?)/) { "::#{$1.upcase}" }
+          str.gsub!(/(?:_+|-+)([a-z]|[0-9])/) { $1.upcase }
+          str.gsub!(/(\A|\s)([A-Z])/) { $1 + $2.downcase }
+          str
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Our company enforces that we do not depend on gems that monkey patch core Ruby classes. To enable us to depend on this gem, this change moves the `lower_camelcase` to be a static method on a new utility class `NetSuite::Utilities::Strings`.

There are many places where `lower_camelcase` is used to generate a `record_type` so this change consolidates the logic in `NetSuite::Support::Records` and uses it where a record type is expected.