### PR TITLE
Add get_item_availability operation

### DIFF
--- a/lib/netsuite/records/item_availability.rb
+++ b/lib/netsuite/records/item_availability.rb
@@ -16,6 +16,28 @@ module NetSuite
       field :quantity_committed
       field :quantity_available
 
+      def self.get_item_availability(ref_list, credentials={})
+        connection = NetSuite::Configuration.connection({}, credentials)
+        response = connection.call :get_item_availability, message: {
+          "platformMsgs:itemAvailabilityFilter" => {
+            "platformCore:item" => ref_list.to_record
+          }
+        }
+        return false unless response.success?
+
+        result = response.body[:get_item_availability_response][:get_item_availability_result]
+        unless result[:status][:@is_success] == "true"
+          return false
+        end
+        if result[:item_availability_list]
+          result[:item_availability_list][:item_availability].map do |row|
+            NetSuite::Records::ItemAvailability.new(row)
+          end
+        else
+          []
+        end
+      end
+
       def initialize(attributes = {})
         initialize_from_attributes_hash(attributes)
       end

--- a/spec/netsuite/records/item_availability_spec.rb
+++ b/spec/netsuite/records/item_availability_spec.rb
@@ -1,25 +1,59 @@
 require 'spec_helper'
 
-module NetSuite
-  module Records
-    describe ItemAvailability do
-      let(:item_availability) { NetSuite::Records::ItemAvailability.new }
+describe NetSuite::Records::ItemAvailability do
+  before(:all) { savon.mock!  }
+  after(:all) { savon.unmock! }
 
-      it 'has all the right fields' do
-        [
-          :quantity_on_hand,
-          :on_hand_value_mli,
-          :reorder_point,
-          :quantity_on_order,
-          :quantity_committed,
-          :quantity_available,
-        ].each do |field|
-          expect(item_availability).to have_field(field)
-        end
-      end
+  let(:item_availability) { NetSuite::Records::ItemAvailability.new }
 
-      it { expect(item_availability).to have_field(:item, InventoryItem) }
-      it { expect(item_availability).to have_field(:location_id, Location) }
+  it 'has all the right fields' do
+    [
+      :quantity_on_hand,
+      :on_hand_value_mli,
+      :reorder_point,
+      :quantity_on_order,
+      :quantity_committed,
+      :quantity_available,
+    ].each do |field|
+      expect(item_availability).to have_field(field)
+    end
+  end
+
+  it { expect(item_availability).to have_field(:item, NetSuite::Records::InventoryItem) }
+  it { expect(item_availability).to have_field(:location_id, NetSuite::Records::Location) }
+
+  describe 'get_item_availability' do
+    let(:inventory_item_ref_list) { 
+      NetSuite::Records::RecordRefList.new(
+        record_ref: [
+          NetSuite::Records::RecordRef.new(internal_id: 57)
+        ]
+      )
+    }
+    let(:result) { NetSuite::Records::ItemAvailability.get_item_availability(inventory_item_ref_list) }
+
+    before do
+      savon.expects(:get_item_availability).with(:message => {
+        "platformMsgs:itemAvailabilityFilter" => {
+          "platformCore:item"=>{"platformCore:recordRef"=>[{:@internalId=>57}]}
+        }
+      }).returns(File.read('spec/support/fixtures/get_item_availability/get_item_availability.xml'))
+    end
+
+    it 'returns ItemAvailability records' do
+      expect(result).to be_kind_of(Array)
+      expect(result).not_to be_empty
+      expect(result[0]).to be_kind_of(NetSuite::Records::ItemAvailability)
+      expect(result[0]).to have_attributes(
+        item: be_kind_of(NetSuite::Records::InventoryItem),
+        location_id: NetSuite::Records::Location,
+        quantity_on_hand: '264.0',
+        on_hand_value_mli: '129.36',
+        reorder_point: '50.0',
+        quantity_on_order: '0.0',
+        quantity_committed: '0.0',
+        quantity_available: '264.0',
+      )
     end
   end
 end

--- a/spec/support/fixtures/get_item_availability/get_item_availability.xml
+++ b/spec/support/fixtures/get_item_availability/get_item_availability.xml
@@ -1,0 +1,46 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Header>
+    <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2016_2.platform.webservices.netsuite.com">
+      <platformMsgs:nsId>WEBSERVICES_3868171_122020162073815481885806769_24761121647f</platformMsgs:nsId>
+    </platformMsgs:documentInfo>
+  </soapenv:Header>
+  <soapenv:Body>
+    <getItemAvailabilityResponse xmlns="urn:messages_2016_2.platform.webservices.netsuite.com">
+      <platformCore:getItemAvailabilityResult xmlns:platformCore="urn:core_2016_2.platform.webservices.netsuite.com">
+        <platformCore:status isSuccess="true"/>
+        <platformCore:itemAvailabilityList>
+          <platformCore:itemAvailability>
+            <platformCore:item internalId="57" type="inventoryItem">
+              <platformCore:name>CD-R</platformCore:name>
+            </platformCore:item>
+            <platformCore:lastQtyAvailableChange>2022-05-05T03:40:06.000-07:00</platformCore:lastQtyAvailableChange>
+            <platformCore:locationId internalId="1" type="location">
+              <platformCore:name>Warehouse - East Coast</platformCore:name>
+            </platformCore:locationId>
+            <platformCore:quantityOnHand>264.0</platformCore:quantityOnHand>
+            <platformCore:onHandValueMli>129.36</platformCore:onHandValueMli>
+            <platformCore:reorderPoint>50.0</platformCore:reorderPoint>
+            <platformCore:quantityOnOrder>0.0</platformCore:quantityOnOrder>
+            <platformCore:quantityCommitted>0.0</platformCore:quantityCommitted>
+            <platformCore:quantityAvailable>264.0</platformCore:quantityAvailable>
+          </platformCore:itemAvailability>
+          <platformCore:itemAvailability>
+            <platformCore:item internalId="57" type="inventoryItem">
+              <platformCore:name>CD-R</platformCore:name>
+            </platformCore:item>
+            <platformCore:lastQtyAvailableChange>2020-04-27T08:38:20.000-07:00</platformCore:lastQtyAvailableChange>
+            <platformCore:locationId internalId="2" type="location">
+              <platformCore:name>Warehouse - West Coast</platformCore:name>
+            </platformCore:locationId>
+            <platformCore:quantityOnHand>-1.0</platformCore:quantityOnHand>
+            <platformCore:onHandValueMli>0.0</platformCore:onHandValueMli>
+            <platformCore:reorderPoint>50.0</platformCore:reorderPoint>
+            <platformCore:quantityOnOrder>0.0</platformCore:quantityOnOrder>
+            <platformCore:quantityCommitted>0.0</platformCore:quantityCommitted>
+            <platformCore:quantityAvailable>0.0</platformCore:quantityAvailable>
+          </platformCore:itemAvailability>
+        </platformCore:itemAvailabilityList>
+      </platformCore:getItemAvailabilityResult>
+    </getItemAvailabilityResponse>
+  </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
Add get_item_availability operation that fetches ItemAvailability records for a list of InventoryItem refs.

https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N3498308.html

Is NetSuite::Records::ItemAvailability class the right place for this operation? Or should it go to Actions?