### PR TITLE
Expose `errors` after calls to `delete` action

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@ The following were removed as `fields` since their sublist class is not yet impl
 * Add search-only fields to `Customer` (#535)
 * Add `attach_file` action to `Customer` records (#544)
 * Add `update` action to `File` records (#544)
+* Expose `errors` after calls to `delete` action (#545)
 
 ### Fixed
 

--- a/lib/netsuite/actions/delete.rb
+++ b/lib/netsuite/actions/delete.rb
@@ -65,6 +65,20 @@ module NetSuite
         @response_body ||= response_hash[:base_ref]
       end
 
+      def response_errors
+        if response_hash[:status] && response_hash[:status][:status_detail]
+          @response_errors ||= errors
+        end
+      end
+
+      def errors
+        error_obj = response_hash[:status][:status_detail]
+        error_obj = [error_obj] if error_obj.class == Hash
+        error_obj.map do |error|
+          NetSuite::Error.new(error)
+        end
+      end
+
       module Support
         def delete(options = {}, credentials={})
           response =  if options.empty?
@@ -72,6 +86,9 @@ module NetSuite
                       else
                         NetSuite::Actions::Delete.call([self, options], credentials)
                       end
+
+          @errors = response.errors
+
           response.success?
         end
       end

--- a/spec/netsuite/actions/delete_spec.rb
+++ b/spec/netsuite/actions/delete_spec.rb
@@ -9,24 +9,84 @@ describe NetSuite::Actions::Delete do
       NetSuite::Records::Customer.new(:internal_id => '980', :entity_id => 'Shutter Fly', :company_name => 'Shutter Fly, Inc.')
     end
 
-    before do
-      savon.expects(:delete).with(:message => {
-        'platformMsgs:baseRef' => {
-          '@internalId' => '980',
-          '@type'       => 'customer',
-          '@xsi:type'   => 'platformCore:RecordRef'
-        },
-      }).returns(File.read('spec/support/fixtures/delete/delete_customer.xml'))
+    context 'when successful' do
+      before do
+        savon.expects(:delete).with(:message => {
+          'platformMsgs:baseRef' => {
+            '@internalId' => '980',
+            '@type'       => 'customer',
+            '@xsi:type'   => 'platformCore:RecordRef'
+          },
+        }).returns(File.read('spec/support/fixtures/delete/delete_customer.xml'))
+      end
+
+      it 'makes a valid request to the NetSuite API' do
+        NetSuite::Actions::Delete.call([customer])
+      end
+
+      it 'returns a valid Response object' do
+        response = NetSuite::Actions::Delete.call([customer])
+        expect(response).to be_kind_of(NetSuite::Response)
+        expect(response).to be_success
+      end
     end
 
-    it 'makes a valid request to the NetSuite API' do
-      NetSuite::Actions::Delete.call([customer])
+    context 'when not successful' do
+      before do
+        savon.expects(:delete).with(:message => {
+          'platformMsgs:baseRef' => {
+            '@xsi:type' => 'platformCore:RecordRef',
+            '@internalId' => '980',
+            '@type' => 'customer',
+          },
+        }).returns(File.read('spec/support/fixtures/delete/delete_customer_error.xml'))
+      end
+
+      it 'provides an error method on the object with details about the error' do
+        customer.delete
+        error = customer.errors.first
+
+        expect(error).to be_kind_of(NetSuite::Error)
+        expect(error.type).to eq('ERROR')
+        expect(error.code).to eq('INSUFFICIENT_PERMISSION')
+        expect(error.message).to eq("Permission Violation: You need a higher level of the 'Lists -> Documents and Files' permission to access this page. Please contact your account administrator.")
+      end
+
+      it 'provides an error method on the response' do
+        response = NetSuite::Actions::Delete.call([customer])
+        expect(response.errors.first).to be_kind_of(NetSuite::Error)
+      end
     end
 
-    it 'returns a valid Response object' do
-      response = NetSuite::Actions::Delete.call([customer])
-      expect(response).to be_kind_of(NetSuite::Response)
-      expect(response).to be_success
+    context 'when not successful with multiple errors' do
+      before do
+        savon.expects(:delete).with(:message => {
+          'platformMsgs:baseRef' => {
+            '@xsi:type' => 'platformCore:RecordRef',
+            '@internalId' => '980',
+            '@type' => 'customer',
+          },
+        }).returns(File.read('spec/support/fixtures/delete/delete_customer_multiple_errors.xml'))
+      end
+
+      it 'provides an error method on the object with details about the error' do
+        customer.delete
+        expect(customer.errors.length).to eq(2)
+
+        error = customer.errors.first
+
+        expect(error).to be_kind_of(NetSuite::Error)
+        expect(error.type).to eq('ERROR')
+        expect(error.code).to eq('INSUFFICIENT_PERMISSION')
+        expect(error.message).to eq("Permission Violation: You need a higher level of the 'Lists -> Documents and Files' permission to access this page. Please contact your account administrator.")
+
+        error = customer.errors[1]
+
+        expect(error).to be_kind_of(NetSuite::Error)
+        expect(error.type).to eq('ERROR')
+        expect(error.code).to eq('SOMETHING_ELSE')
+        expect(error.message).to eq('Another error.')
+      end
     end
   end
 

--- a/spec/support/fixtures/delete/delete_customer_error.xml
+++ b/spec/support/fixtures/delete/delete_customer_error.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Header>
+    <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2020_2.platform.webservices.netsuite.com">
+      <platformMsgs:nsId>WEBSERVICES_3392464_1220201115821392011296470399_67055c545d0</platformMsgs:nsId>
+    </platformMsgs:documentInfo>
+  </soapenv:Header>
+  <soapenv:Body>
+    <deleteResponse xmlns="urn:messages_2020_2.platform.webservices.netsuite.com">
+      <writeResponse>
+        <platformCore:status xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com" isSuccess="false">
+          <platformCore:statusDetail type="ERROR">
+            <platformCore:code>INSUFFICIENT_PERMISSION</platformCore:code>
+            <platformCore:message>Permission Violation: You need a higher level of the 'Lists -&gt; Documents and Files' permission to access this page. Please contact your account administrator.</platformCore:message>
+          </platformCore:statusDetail>
+        </platformCore:status>
+        <baseRef xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com" internalId="118519" type="file" xsi:type="platformCore:RecordRef"/>
+      </writeResponse>
+    </deleteResponse>
+  </soapenv:Body>
+</soapenv:Envelope>

--- a/spec/support/fixtures/delete/delete_customer_multiple_errors.xml
+++ b/spec/support/fixtures/delete/delete_customer_multiple_errors.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Header>
+    <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2020_2.platform.webservices.netsuite.com">
+      <platformMsgs:nsId>WEBSERVICES_3392464_1220201115821392011296470399_67055c545d0</platformMsgs:nsId>
+    </platformMsgs:documentInfo>
+  </soapenv:Header>
+  <soapenv:Body>
+    <deleteResponse xmlns="urn:messages_2020_2.platform.webservices.netsuite.com">
+      <writeResponse>
+        <platformCore:status xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com" isSuccess="false">
+          <platformCore:statusDetail type="ERROR">
+            <platformCore:code>INSUFFICIENT_PERMISSION</platformCore:code>
+            <platformCore:message>Permission Violation: You need a higher level of the 'Lists -&gt; Documents and Files' permission to access this page. Please contact your account administrator.</platformCore:message>
+          </platformCore:statusDetail>
+          <platformCore:statusDetail type="ERROR">
+            <platformCore:code>SOMETHING_ELSE</platformCore:code>
+            <platformCore:message>Another error.</platformCore:message>
+          </platformCore:statusDetail>
+        </platformCore:status>
+        <baseRef xmlns:platformCore="urn:core_2020_2.platform.webservices.netsuite.com" internalId="118519" type="file" xsi:type="platformCore:RecordRef"/>
+      </writeResponse>
+    </deleteResponse>
+  </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
If the `delete` action returned false due to a NetSuite error, there
wasn't a way to access those errors. Now you can call `errors` on the
instance you tried deleting to access them, just like when adding,
updating, etc. instances.