### PR TITLE
Add optional proxy for NetSuite requests through Savon

### DIFF
--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -27,6 +27,7 @@ module NetSuite
         logger: logger,
         log_level: log_level,
         log: !silent, # turn off logging entirely if configured
+        proxy: proxy,
       }.update(params))
       cache_wsdl(client)
       return client
@@ -393,6 +394,18 @@ module NetSuite
 
     def log_level=(value)
       attributes[:log_level] = value
+    end
+
+    def proxy=(proxy)
+      attributes[:proxy] = proxy
+    end
+
+    def proxy(proxy = nil)
+      if proxy
+        self.proxy = proxy
+      else
+        attributes[:proxy]
+      end
     end
   end
 end

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -476,4 +476,25 @@ describe NetSuite::Configuration do
     end
   end
 
+  describe '#proxy' do
+    it 'defaults to nil' do
+      expect(config.proxy).to be_nil
+    end
+
+    it 'can be set with proxy=' do
+      config.proxy = "https://my-proxy"
+
+      expect(config.proxy).to eql("https://my-proxy")
+
+      # ensure no exception is raised
+      config.connection
+    end
+
+    it 'can be set with proxy(value)' do
+      config.proxy("https://my-proxy")
+
+      expect(config.proxy).to eql("https://my-proxy")
+    end
+  end
+
 end


### PR DESCRIPTION
This change adds an optional `proxy` attribute on the `NetSuite::Configuration` that is passed to the generated Savon client used for requests to NetSuite.