### PR TITLE
Optionally pass in `proxy` parameter to Savon

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ The following were removed as `fields` since their sublist class is not yet impl
 * Add `update` action to `File` records (#544)
 * Expose `errors` after calls to `delete` action (#545)
 * Add `update_list` action where missing on supported item records (#546)
+* Add `proxy` attribute to `NetSuite::Configuration` to set a proxy used by the savon client (#547)
 
 ### Fixed
 

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -15,8 +15,6 @@ module NetSuite
     end
 
     def connection(params={}, credentials={})
-      proxy_params = proxy ? {proxy: proxy} : {}
-      
       client = Savon.client({
         wsdl: cached_wsdl || wsdl,
         endpoint: endpoint,
@@ -29,7 +27,8 @@ module NetSuite
         logger: logger,
         log_level: log_level,
         log: !silent, # turn off logging entirely if configured
-      }.update(proxy_params).update(params))
+      }.update(params))
+      client.globals.proxy(proxy) if proxy
       cache_wsdl(client)
       return client
     end

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -15,6 +15,8 @@ module NetSuite
     end
 
     def connection(params={}, credentials={})
+      proxy_params = proxy ? {proxy: proxy} : {}
+      
       client = Savon.client({
         wsdl: cached_wsdl || wsdl,
         endpoint: endpoint,
@@ -27,8 +29,7 @@ module NetSuite
         logger: logger,
         log_level: log_level,
         log: !silent, # turn off logging entirely if configured
-        proxy: proxy,
-      }.update(params))
+      }.update(proxy_params).update(params))
       cache_wsdl(client)
       return client
     end

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -481,13 +481,21 @@ describe NetSuite::Configuration do
       expect(config.proxy).to be_nil
     end
 
+    it 'does not pass in nil proxy to savon' do
+      connection = config.connection
+
+      expect(connection.globals.include?(:proxy)).to eql(false)
+    end
+
     it 'can be set with proxy=' do
       config.proxy = "https://my-proxy"
 
       expect(config.proxy).to eql("https://my-proxy")
 
       # ensure no exception is raised
-      config.connection
+      connection = config.connection
+
+      expect(connection.globals.include?(:proxy)).to eql(true)
     end
 
     it 'can be set with proxy(value)' do


### PR DESCRIPTION
Savon will call `to_s` on any `proxy` value passed in so it will treat `nil` like an empty string instead of not using it. This causes requests to fail with an invalid proxy. This change will not pass in a value for `proxy` if the attribute is `nil`.

This change also updates history with addition of the proxy attribute.

A [fix was added to version 2.12.0 of savon](https://github.com/savonrb/savon/blob/master/CHANGELOG.md#2120-2018-01-16) but this changes allows netsuite to be compatible with earlier versions of savon.