### PR TITLE
Making gem thread safe

### DIFF
--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -51,7 +51,7 @@ module NetSuite
     end
 
     def wsdl_cache
-      @wsdl_cache ||= {}
+      Thread.current[:netsuite_gem_wsdl_cache] ||= {}
     end
 
     def clear_wsdl_cache

--- a/lib/netsuite/utilities.rb
+++ b/lib/netsuite/utilities.rb
@@ -203,7 +203,6 @@ module NetSuite
       opts[:external_id] ||= false
 
       if opts[:cache]
-        netsuite_get_record_cache ||= {}
         netsuite_get_record_cache[record_klass.to_s] ||= {}
 
         if netsuite_get_record_cache[record_klass.to_s].has_key?(id.to_i)
@@ -228,7 +227,7 @@ module NetSuite
       rescue ::NetSuite::RecordNotFound
         # log.warn("record not found", ns_record_type: record_klass.name, ns_record_id: id)
         if opts[:cache]
-          @netsuite_get_record_cache[record_klass.to_s][id.to_i] = nil
+          netsuite_get_record_cache[record_klass.to_s][id.to_i] = nil
         end
 
         return nil
@@ -243,8 +242,6 @@ module NetSuite
       # FIXME: Records that have the same name but different types will break
       # the cache
       names.each do |name|
-        netsuite_find_record_cache ||= {}
-
         if netsuite_find_record_cache.has_key?(name)
           return netsuite_find_record_cache[name]
         end

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -14,6 +14,20 @@ describe NetSuite::Configuration do
       config.reset!
       expect(config.attributes).to be_empty
     end
+
+    it 'ensures that attributes are not shared between threads' do
+      config.attributes[:blah] = 'something'
+      expect(config.attributes[:blah]).to eq('something')
+
+      thread = Thread.new {
+        config.attributes[:blah] = 'something_else'
+        expect(config.attributes[:blah]).to eq('something_else')
+      }
+
+      thread.join
+
+      expect(config.attributes[:blah]).to eq('something')
+    end
   end
 
   describe '#filters' do


### PR DESCRIPTION
Making gem thread safe by wrapping instance variables in `Thread.current`. All tests are passing.