### PR TITLE
Ignore status detail of after_submit_failed in error handling

### DIFF
--- a/lib/netsuite/actions/add.rb
+++ b/lib/netsuite/actions/add.rb
@@ -70,8 +70,9 @@ module NetSuite
         error_obj = response_hash[:status][:status_detail]
         error_obj = [error_obj] if error_obj.class == Hash
         error_obj.map do |error|
+          next if error.keys == [:after_submit_failed]
           NetSuite::Error.new(error)
-        end
+        end.compact
       end
 
       module Support

--- a/spec/netsuite/actions/add_spec.rb
+++ b/spec/netsuite/actions/add_spec.rb
@@ -53,10 +53,11 @@ describe NetSuite::Actions::Add do
         NetSuite::Actions::Add.call([invoice])
       end
 
-      it 'returns a valid Response object' do
+      it 'returns a valid Response object with no errors' do
         response = NetSuite::Actions::Add.call([invoice])
         expect(response).to be_kind_of(NetSuite::Response)
         expect(response).to be_success
+        expect(response.errors).to be_empty
       end
     end
 
@@ -136,10 +137,11 @@ describe NetSuite::Actions::Add do
         NetSuite::Actions::Add.call([file])
       end
 
-      it 'returns a valid Response object' do
+      it 'returns a valid Response object with no errors' do
         response = NetSuite::Actions::Add.call([file])
         expect(response).to be_kind_of(NetSuite::Response)
         expect(response).to be_success
+        expect(response.errors).to be_empty
       end
 
       it 'properly extracts internal ID from response' do

--- a/spec/support/fixtures/add/add_invoice.xml
+++ b/spec/support/fixtures/add/add_invoice.xml
@@ -1,15 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <soapenv:Header>
-    <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2011_2.platform.webservices.netsuite.com">
+    <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2018_2.platform.webservices.netsuite.com">
       <platformMsgs:nsId>WEBSERVICES_3392464_1220201115821392011296470399_67055c545d0</platformMsgs:nsId>
     </platformMsgs:documentInfo>
   </soapenv:Header>
   <soapenv:Body>
-    <addResponse xmlns="urn:messages_2_5.platform.webservices.netsuite.com">
-      <writeResponse xmlns="urn:messages_2_5.platform.webservices.netsuite.com">
-        <ns1:status isSuccess="true" xmlns:ns1="urn:core_2_5.platform.webservices.netsuite.com"/>
-        <baseRef internalId="999" type="invoice" xsi:type="ns2:RecordRef" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns2="urn:core_2_5.platform.webservices.netsuite.com"/>
+    <addResponse xmlns="urn:messages_2018_2.platform.webservices.netsuite.com">
+      <writeResponse>
+        <platformCore:status isSuccess="true" xmlns:platformCore="urn:core_2018_2.platform.webservices.netsuite.com">
+          <platformCore:statusDetail>
+            <platformCore:afterSubmitFailed>false</platformCore:afterSubmitFailed>
+          </platformCore:statusDetail>
+        </platformCore:status>
+        <baseRef internalId="999" type="invoice" xsi:type="platformCore:RecordRef" xmlns:platformCore="urn:core_2018_2.platform.webservices.netsuite.com"/>
       </writeResponse>
     </addResponse>
   </soapenv:Body>


### PR DESCRIPTION
Addresses issue [#444](https://github.com/NetSweet/netsuite/issues/444), where some successful requests return an empty error object.

See https://system.netsuite.com/help/helpcenter/en_US/WSDiff/2018_2/FolderComparisonReport_files/FileComparisonReport24.html, line 914 for the change to the platformCore schema, https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_4407992281.html for a description of afterSubmit scripts, and https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N3536574.html#bridgehead_1515748728 for a discussion of error reporting for these scripts.

Also adds a line for File requests in the add action spec b/c the existing fixture already includes the `after_submit_failed` field.

Co-authored-by: Lily Burtness <lily.burtness@charitywater.org>
Co-authored-by: Shana Schundler <shana.schundler@charitywater.org>