### PR TITLE
Copy configuration attributes from main thread to child threads

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,8 @@
 
 ### Added
 ### Fixed
+* Copy configuration attributes from main thread to child threads (#555)
+
 ### Breaking Changes
 
 ## 0.9.0

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -11,7 +11,7 @@ module NetSuite
     end
 
     def attributes
-      Thread.current[:netsuite_gem_attributes] ||= {}
+      Thread.current[:netsuite_gem_attributes] ||= (Thread.main[:netsuite_gem_attributes] || {}).dup
     end
 
     def connection(params={}, credentials={})

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -15,11 +15,12 @@ describe NetSuite::Configuration do
       expect(config.attributes).to be_empty
     end
 
-    it 'ensures that attributes are not shared between threads' do
+    it 'ensures that attributes are copied from the main thread but changes within a child thread are not shared back to the main thread' do
       config.attributes[:blah] = 'something'
       expect(config.attributes[:blah]).to eq('something')
 
       thread = Thread.new {
+        expect(config.attributes[:blah]).to eq('something')
         config.attributes[:blah] = 'something_else'
         expect(config.attributes[:blah]).to eq('something_else')
       }


### PR DESCRIPTION
This is a follow up to #549 to improve usage in a single tenant scenario where you might configure NetSuite on the main thread (ie. via Rails initializer), then make requests in another thread (ie. Sidekiq jobs). Instead of each thread starting with an empty configuration, child threads now start with the main thread's configuration.

I'm mainly opening this just to start discussion around some concrete code. It may not be ready for a merge yet.

I'm not sure if we need an explicit single vs. multi-tenant configuration option. Having the new threads start with a copy of the main thread's configuration seems better. In a multi-tenant scenario, this way you can still set some general configuration (ie. timeouts, logging, proxy, etc.) on the main thread and have it apply to all child threads, then in the child threads you just have to configure whatever's unique to that tenant (ie. account, credentials, etc.), which wont leak back to the main thread or future child threads.

I didn't touch the caches (WSDL or record) that were changed in #549. As a result, in a single-tenant scenario with requests happening in child threads (ie. Sidekiq jobs), I think each thread (job) will cache the WSDL separately, which defeats the purpose of a cache a bit. Previously I believe the WSDL was cached globally (to the detriment of multi-tenant scenarios). Perhaps this is where the single vs multi-tenant configuration option comes into play to be explicit about where we cache? The same likely applies for the record cache. Maybe we need slightly different rules for where we store things (`Thread.current` vs `Thread.main`) whether we're talking about configuration attributes or caches.

@andrewdicken-stripe perhaps you could weigh in as the original author, assuming your use-case might be multi-tenant?