### PR TITLE
Add `Configuration#multi_tenant!` for opting into multi-tentant support where configuration is per-thread

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,8 @@
 
 
 ### Added
+* Add `Configuration#multi_tenant!` for opting into multi-tentant support where configuration/caching is per-thread (#556)
+
 ### Fixed
 * Locked Savon to version `< 2.13` to prevent XML parsing issues.
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -159,6 +159,30 @@ NetSuite.configure do
 end
 ```
 
+### Multi-Tenancy
+
+If you're interacting with multiple NetSuite accounts, each in separate threads, you can enable multi-tenancy to prevent your configuration and caches from being shared between threads.
+
+From your main thread, you'd want to enable multi-tenancy:
+
+```ruby
+NetSuite.configure do
+  multi_tentant!
+end
+```
+
+Then in each child thread, you'd perform any configuration specific to the NetSuite account you're interacting with for that thread, all of which will be specific to that thread only:
+
+```ruby
+NetSuite.configure do
+  reset!
+
+  account ENV['NETSUITE_ACCOUNT']
+
+  # The rest of your usual configuration...
+end
+```
+
 # Usage
 
 ## CRUD Operations

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ NetSuite.configure do
 end
 ```
 
+Note that `multi_tenant!` is a special configuration option which is _not_ effected by `reset!`.
+
 Then in each child thread, you'd perform any configuration specific to the NetSuite account you're interacting with for that thread, all of which will be specific to that thread only:
 
 ```ruby

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -11,7 +11,11 @@ module NetSuite
     end
 
     def attributes
-      Thread.current[:netsuite_gem_attributes] ||= {}
+      if multi_tenant?
+        Thread.current[:netsuite_gem_attributes] ||= {}
+      else
+        @attributes ||= {}
+      end
     end
 
     def connection(params={}, credentials={})
@@ -51,11 +55,19 @@ module NetSuite
     end
 
     def wsdl_cache
-      Thread.current[:netsuite_gem_wsdl_cache] ||= {}
+      if multi_tenant?
+        Thread.current[:netsuite_gem_wsdl_cache] ||= {}
+      else
+        @wsdl_cache ||= {}
+      end
     end
 
     def clear_wsdl_cache
-      Thread.current[:netsuite_gem_wsdl_cache] = {}
+      if multi_tenant?
+        Thread.current[:netsuite_gem_wsdl_cache] = {}
+      else
+        @wsdl_cache = {}
+      end
     end
 
     def cached_wsdl
@@ -406,6 +418,14 @@ module NetSuite
       else
         attributes[:proxy]
       end
+    end
+
+    def multi_tenant!
+      @multi_tenant = true
+    end
+
+    def multi_tenant?
+      @multi_tenant
     end
   end
 end

--- a/lib/netsuite/utilities.rb
+++ b/lib/netsuite/utilities.rb
@@ -7,18 +7,31 @@ module NetSuite
     # TODO need structured logger for various statements
 
     def clear_cache!
-      Thread.current[:netsuite_gem_netsuite_get_record_cache] = {}
-      Thread.current[:netsuite_gem_netsuite_find_record_cache] = {}
+      if NetSuite::Configuration.multi_tenant?
+        Thread.current[:netsuite_gem_netsuite_get_record_cache] = {}
+        Thread.current[:netsuite_gem_netsuite_find_record_cache] = {}
+      else
+        @netsuite_get_record_cache = {}
+        @netsuite_find_record_cache = {}
+      end
 
       DataCenter.clear_cache!
     end
 
     def netsuite_get_record_cache
-      Thread.current[:netsuite_gem_netsuite_get_record_cache] ||= {}
+      if NetSuite::Configuration.multi_tenant?
+        Thread.current[:netsuite_gem_netsuite_get_record_cache] ||= {}
+      else
+        @netsuite_get_record_cache ||= {}
+      end
     end
 
     def netsuite_find_record_cache
-      Thread.current[:netsuite_gem_netsuite_find_record_cache] ||= {}
+      if NetSuite::Configuration.multi_tenant?
+        Thread.current[:netsuite_gem_netsuite_find_record_cache] ||= {}
+      else
+        @netsuite_find_record_cache ||= {}
+      end
     end
 
     def append_memo(ns_record, added_memo, opts = {})


### PR DESCRIPTION
This is a follow up to #549 to improve usage in a single tenant scenario where you might configure NetSuite on the main thread (ie. via Rails initializer), then make requests in another thread (ie. Sidekiq jobs).

By default we assume single-tenant usage and the configuration is shared across all threads. If you opt into multi-tenant usage, each child thread starts with the main thread's configuration, but can then be further configured without altering other threads.

Rather than mixing `Thread.current` and global instance variables, I'm using `Thread.main` for the global configuration.

Child threads start with a copy of the main thread's attributes, figuring this still allows you to set some things globally on the main thread (ie. timeouts), then per-tenant things on the child threads (ie. account).

Whether we're multi-tentant or not is always stored on the main thread, not as an attribute, as we want/need that to be global.

One possible concern is what happens if you set some configuration before calling `multi_tenant!`, particularly when called from a child thread. Whatever configuration you set before `multi_tenant!` would be stored on the main thread (thinking we're single-tenant), not the child thread, which could be surprising. Maybe we need a safety check so it'll error if you call `multi_tenant!` after attributes have already been set, forcing you to specify `multi_tentant!` first?

`reset!` also resets whether it's multi-tenant, taking the stance that it's a full reset, not just resetting the thread.

I didn't touch caches yet, wanted to make sure we're on the right path first. I'll need to mention this in the README too.