### PR TITLE
Locking Savon to < 2.13 to prevent an error making queries

### DIFF
--- a/netsuite.gemspec
+++ b/netsuite.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.metadata['mailing_list_uri'] = 'http://opensuite-slackin.herokuapp.com'
   gem.metadata['rubygems_mfa_required'] = 'true'
 
-  gem.add_dependency 'savon', '>= 2.3.0'
+  gem.add_dependency 'savon', '>= 2.3.0', '< 2.13'
 
   gem.add_development_dependency 'rspec', '~> 3.11.0'
   gem.add_development_dependency 'rake', '~> 12.3.3'


### PR DESCRIPTION
Making a request with the NetSuite gem and Savon 2.13.0 caused the following error:

```
<faultstring>org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 435; The prefix "xmlns" cannot be bound to any namespace explicitly; neither can the namespace for "xmlns" be bound to any prefix explicitly.
```

Therefore, this PR locks the Savon gem to the last versions that work.

If I had to guess at the PR that caused the issue, I would suggest it is [this](https://github.com/savonrb/savon/pull/943) one.