### PR TITLE
Avoid Savon version `2.13.0` to prevent generating invalid envelopes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,10 @@ if ENV.fetch('BUNDLE_TZINFO', 'false') == 'true'
   # optional dependency for more accurate timezone conversion
   gem 'tzinfo', '>= 1.2.5'
 end
+
+if RUBY_VERSION >= '3.1.0'
+  # Savon v2.13 adds a dependency on mail, which has an implicit dependency on
+  # net-smtp. Ruby 3.1 removed net-smtp as a default gem. mail v2.8.0.rc1 is the
+  # first to make that dependency explicit to support Ruby 3.1.
+  gem 'mail', '>= 2.8.0.rc1'
+end

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,8 @@
 * Add `Configuration#multi_tenant!` for opting into multi-tentant support where configuration/caching is per-thread (#556)
 
 ### Fixed
-* Locked Savon to version `< 2.13` to prevent XML parsing issues.
+* Avoid Savon version `2.13.0` to prevent generating invalid envelopes. (#558, #563)
+
 ### Breaking Changes
 
 ## 0.9.0

--- a/netsuite.gemspec
+++ b/netsuite.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.metadata['mailing_list_uri'] = 'http://opensuite-slackin.herokuapp.com'
   gem.metadata['rubygems_mfa_required'] = 'true'
 
-  gem.add_dependency 'savon', '>= 2.3.0', '< 2.13'
+  gem.add_dependency 'savon', '>= 2.3.0', '!= 2.13.0'
 
   gem.add_development_dependency 'rspec', '~> 3.11.0'
   gem.add_development_dependency 'rake', '~> 12.3.3'


### PR DESCRIPTION
This version of Savon mistakenly prefixed the default namespace of `xmlns`, resulting in a namespace of `xmlns:xmlns`, which caused NetSuite to error on requests. v2.13.1 fixed this issue to skip prefixing the default namespace.

This is a continuation of #558, which avoided v2.13.0 and anything greater.

Bug: https://github.com/savonrb/savon/pull/943#issuecomment-1213163418
Fix: https://github.com/savonrb/savon/pull/977