### PR TITLE
Update HISTORY.md for v0.9.1 release [ci skip]

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,13 +1,22 @@
 ## Unreleased
 
+### Added
+
+### Fixed
+
+### Breaking Changes
+
+## v0.9.1
 
 ### Added
 * Add `Configuration#multi_tenant!` for opting into multi-tentant support where configuration/caching is per-thread (#556)
 
 ### Fixed
 * Avoid Savon version `2.13.0` to prevent generating invalid envelopes. (#558, #563)
+* Retry on `HTTPI::SSLError` and `HTTPI::TimeoutError` in backoff (#566)
 
 ### Breaking Changes
+* Update default API version to 2016_2 from 2015_1 when `api_version` is not explicitly set (#554)
 
 ## 0.9.0
 


### PR DESCRIPTION
I noted the change to the default API version as a breaking change, as it could be if someone wasn't setting an `api_version` explicitly, relying on the default being `2015_1`, and doing something that might not be compatible with `2016_2`, though based on #554, it sounds like NetSuite isn't even supporting `2015_1` anymore, so the requests were probably failing already.