### PR TITLE
Invoice shipping_tax_code should be a record_ref

### DIFF
--- a/lib/netsuite/records/invoice.rb
+++ b/lib/netsuite/records/invoice.rb
@@ -25,7 +25,7 @@ module NetSuite
         :other_ref_num, :partners_list, :rev_rec_end_date,
         :rev_rec_on_rev_commitment, :rev_rec_schedule, :rev_rec_start_date, :revenue_status, :sales_effective_date,
         :sales_group, :sales_team_list, :ship_date, :ship_group_list,
-        :shipping_cost, :shipping_tax_1_rate, :shipping_tax_2_rate, :shipping_tax_code, :source, :start_date,
+        :shipping_cost, :shipping_tax_1_rate, :shipping_tax_2_rate, :source, :start_date,
         :status, :sync_partner_teams, :sync_sales_teams, :tax_2_total,
         :tax_total, :time_disc_amount, :time_disc_print, :time_disc_rate, :time_disc_tax_1_amt, :time_disc_taxable,
         :time_discount, :time_list, :time_tax_code, :time_tax_rate_1, :time_tax_rate_2, :to_be_emailed, :to_be_faxed,
@@ -138,7 +138,8 @@ module NetSuite
 
       record_refs :account, :bill_address_list, :custom_form, :department, :entity, :klass, :partner,
                   :posting_period, :ship_address_list, :terms, :location, :sales_rep, :tax_item, :created_from,
-                  :ship_method, :lead_source, :promo_code, :subsidiary, :currency, :approval_status, :job, :discount_item
+                  :ship_method, :lead_source, :promo_code, :subsidiary, :currency, :approval_status, :job, :discount_item,
+                  :shipping_tax_code
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/spec/netsuite/records/invoice_spec.rb
+++ b/spec/netsuite/records/invoice_spec.rb
@@ -21,7 +21,7 @@ describe NetSuite::Records::Invoice do
       :other_ref_num, :partners_list, :rev_rec_end_date,
       :rev_rec_on_rev_commitment, :rev_rec_schedule, :rev_rec_start_date, :revenue_status, :sales_effective_date,
       :sales_group, :sales_team_list, :ship_address, :ship_date, :ship_group_list,
-      :shipping_cost, :shipping_tax_1_rate, :shipping_tax_2_rate, :shipping_tax_code, :source, :start_date,
+      :shipping_cost, :shipping_tax_1_rate, :shipping_tax_2_rate, :source, :start_date,
       :status, :sync_partner_teams, :sync_sales_teams, :tax_2_total,
       :tax_total, :time_disc_amount, :time_disc_print, :time_disc_rate, :time_disc_tax_1_amt, :time_disc_taxable,
       :time_discount, :time_list, :time_tax_code, :time_tax_rate_1, :time_tax_rate_2, :to_be_emailed, :to_be_faxed,
@@ -151,7 +151,8 @@ describe NetSuite::Records::Invoice do
   it 'has the right record_refs' do
     [
       :account, :bill_address_list, :job, :custom_form, :department, :entity, :klass, :posting_period, :ship_address_list, :terms,
-      :created_from, :location, :sales_rep, :ship_method, :tax_item, :partner, :lead_source, :promo_code, :subsidiary, :discount_item
+      :created_from, :location, :sales_rep, :ship_method, :tax_item, :partner, :lead_source, :promo_code, :subsidiary, :discount_item,
+      :shipping_tax_code
     ].each do |record_ref|
       expect(invoice).to have_record_ref(record_ref)
     end


### PR DESCRIPTION
Per the NetSuite schema browser the Invoice shipping_tax_code should be a record_ref, since at least API version 2014_1.