### PR TITLE
dont crash if suitetalk returns empty <platformCore:searchRowList/>

### DIFF
--- a/lib/netsuite/support/search_result.rb
+++ b/lib/netsuite/support/search_result.rb
@@ -48,7 +48,8 @@ module NetSuite
             end
           elsif response.body.has_key? :search_row_list
             # advanced search results
-            record_list = response.body[:search_row_list][:search_row]
+            record_list = response.body[:search_row_list]
+            record_list = record_list ? record_list[:search_row] : []
             record_list = [record_list] unless record_list.is_a?(Array)
 
             record_list.each do |record|

--- a/spec/netsuite/support/search_result_spec.rb
+++ b/spec/netsuite/support/search_result_spec.rb
@@ -22,6 +22,23 @@ describe NetSuite::Support::SearchResult do
         results = described_class.new(response, NetSuite::Actions::Search, {}).results
         expect(results).to eq []
       end
+
+      it 'returns empty search_row_list' do
+        response_body = {
+          :status => {:@is_success=>"true"},
+          :total_records => "242258",
+          :page_size => "10",
+          :total_pages => "24226",
+          :page_index => "99",
+          :search_id => "WEBSERVICES_4132604_SB1_051620191060155623420663266_336cbf12",
+          :search_row_list => nil,
+          :"@xmlns:platform_core" => "urn:core_2016_2.platform.webservices.netsuite.com"
+        }
+        response = NetSuite::Response.new(body: response_body)
+
+        results = described_class.new(response, NetSuite::Actions::Search, {}).results
+        expect(results).to eq []
+      end
     end
 
     it 'handles a recordList with a single element' do


### PR DESCRIPTION
The client should just yield the blank page returned instead of crashing, but to ever receive this seems like a bug in suitetalk since we're using results_in_batches but on the final page sometimes a successful result is returned with no rows, probably because the underlying data no longer matches the search since our pagination takes an hour or so and we're running it across day boundaries, but you'd think search_id would represent an isolated view of the data we're paginating.  we haven't captured the log to see if total_records changes, but obviously total_pages doesn't since it successfully accepts page_index but just doesn't return any rows.  