### PR TITLE
Add :klass field to record VendorReturnAuthorizationItem & VendorReturnAuthorization

### DIFF
--- a/lib/netsuite/records/vendor_return_authorization.rb
+++ b/lib/netsuite/records/vendor_return_authorization.rb
@@ -9,7 +9,7 @@ module NetSuite
 
       actions :get, :get_list, :add, :initialize, :delete, :update, :upsert, :search
 
-      fields :billing_address, :created_date, :memo, :tran_date, :tran_id
+      fields :billing_address, :created_date, :memo, :tran_date, :tran_id, :klass
 
       record_refs :bill_address_list, :department, :entity, :location
 

--- a/lib/netsuite/records/vendor_return_authorization_item.rb
+++ b/lib/netsuite/records/vendor_return_authorization_item.rb
@@ -8,7 +8,7 @@ module NetSuite
 
       fields :amortization_end_date, :amortization_residual, :amount, :bin_numbers, :description,
       :gross_amt, :is_billable, :is_closed, :is_drop_shipment, :line, :order_line, :quantity,
-      :rate, :vendor_name
+      :rate, :vendor_name, :klass
 
       field :inventory_detail, InventoryDetail
 


### PR DESCRIPTION
Add :klass field to record VendorReturnAuthorization and VendorReturnAuthorizationItem

NoMethodError: undefined method `klass=' for #<NetSuite::Records::VendorReturnAuthorizationItem:0x00007fb216d14de8 @attributes={:item=>#<NetSuite::Records::RecordRef:0x00007fb216d1be90 @internal_id="555", @external_id=nil, @type=nil, @attributes={:name=>"0901JKE"}>, :line=>"2", :quantity=>"15.0", :description=>"", :rate=>"0.00", :amount=>"0.0", :location=>#<NetSuite::Records::RecordRef:0x00007fb216d1ba58 @internal_id="63", @external_id=nil, @type=nil, @attributes={:name=>""}>, :is_billable=>false, :is_closed=>false, :is_drop_shipment=>false}>