### PR TITLE
Revert proxy change

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -53,9 +53,6 @@ The following were removed as `fields` since their sublist class is not yet impl
 * Add `update` action to `File` records (#544)
 * Expose `errors` after calls to `delete` action (#545)
 * Add `update_list` action where missing on supported item records (#546)
-* Add `proxy` attribute to `NetSuite::Configuration` to set a proxy used by the savon client (#547)
-
-### Fixed
 * Ignore `after_submit_failed` status details (>= 2018.2) when collating errors in add action (#550)
 * Add `NullFieldList` to `SalesOrder` (#552)
 * Add thread safety to NetSuite configuration and utilities (#549)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -53,6 +53,9 @@ The following were removed as `fields` since their sublist class is not yet impl
 * Add `update` action to `File` records (#544)
 * Expose `errors` after calls to `delete` action (#545)
 * Add `update_list` action where missing on supported item records (#546)
+* Add `proxy` attribute to `NetSuite::Configuration` to set a proxy used by the savon client (#547)
+
+### Fixed
 * Ignore `after_submit_failed` status details (>= 2018.2) when collating errors in add action (#550)
 * Add `NullFieldList` to `SalesOrder` (#552)
 * Add thread safety to NetSuite configuration and utilities (#549)

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -31,8 +31,8 @@ module NetSuite
         logger: logger,
         log_level: log_level,
         log: !silent, # turn off logging entirely if configured
+        proxy: proxy,
       }.update(params))
-      client.globals.proxy(proxy) if proxy
       cache_wsdl(client)
       return client
     end

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -519,21 +519,13 @@ describe NetSuite::Configuration do
       expect(config.proxy).to be_nil
     end
 
-    it 'does not pass in nil proxy to savon' do
-      connection = config.connection
-
-      expect(connection.globals.include?(:proxy)).to eql(false)
-    end
-
     it 'can be set with proxy=' do
       config.proxy = "https://my-proxy"
 
       expect(config.proxy).to eql("https://my-proxy")
 
       # ensure no exception is raised
-      connection = config.connection
-
-      expect(connection.globals.include?(:proxy)).to eql(true)
+      config.connection
     end
 
     it 'can be set with proxy(value)' do


### PR DESCRIPTION
Reverts recent proxy related change, explained further in issue here: https://github.com/NetSweet/netsuite/issues/578. I'm not exactly sure why the proxy change breaks things but this fix should revert the behavior to how it was before.