### PR TITLE
Fix fields definition for Transfer Orders

### DIFF
--- a/lib/netsuite/records/transfer_order.rb
+++ b/lib/netsuite/records/transfer_order.rb
@@ -15,10 +15,11 @@ module NetSuite
              :shipping_tax1_rate, :shipping_tax2_rate, :source, :status, :sub_total,
              :total, :tracking_numbers, :tran_date, :tran_id, :order_status, :use_item_cost_as_transfer_cost
 
-      record_refs :transfer_location, :shipping_tax_code, :subsidiary, :shipping_address,
+      record_refs :transfer_location, :shipping_tax_code, :subsidiary,
                   :ship_method, :employee, :handling_tax_code,
                   :location, :custom_form, :department, :klass, :ship_address_list
 
+      field :shipping_address,    Address
       field :custom_field_list,   CustomFieldList
       field :item_list,           TransferOrderItemList
 

--- a/lib/netsuite/records/transfer_order_item.rb
+++ b/lib/netsuite/records/transfer_order_item.rb
@@ -6,7 +6,7 @@ module NetSuite
       include Support::Records
       include Namespaces::TranInvt
 
-      fields :amount, :average_cost, :klass, :commit_inventory, :description,
+      fields :amount, :average_cost, :commit_inventory, :description,
              :expected_receipt_date, :expected_ship_date, :inventory_detail, :is_closed, :last_purchase_price,
              :line, :order_priority, :quantity, :quantity_available,
              :quantity_back_ordered, :quantity_committed, :quantity_fulfilled,
@@ -16,7 +16,7 @@ module NetSuite
       field :options, CustomFieldList
       field :custom_field_list, CustomFieldList
 
-      record_refs :department, :item, :units
+      record_refs :department, :item, :units, :klass
 
       def initialize(attributes_or_record = {})
         case attributes_or_record


### PR DESCRIPTION
# Problem found
An error occured while making:
- `get` on a Transfer Order
- modify the Transfer Order
- `upsert` the Transfer Order

# Solution
- `shipping_address` has to be an `Address` in `transfer_order`
- `klass` has to be be a `record_ref` in `transfer_order_item`
