### PR TITLE
Added create_wo field item in Invoice Item

### DIFF
--- a/lib/netsuite/records/invoice_item.rb
+++ b/lib/netsuite/records/invoice_item.rb
@@ -12,7 +12,7 @@ module NetSuite
         :options, :order_line, :percent_complete, :quantity, :quantity_available, :quantity_fulfilled,
         :quantity_on_hand, :quantity_ordered, :rate, :rev_rec_end_date, :rev_rec_start_date,
         :serial_numbers, :ship_group, :tax1_amt, :tax_rate1, :tax_rate2, :vsoe_allocation, :vsoe_amount, :vsoe_deferral,
-        :vsoe_delivered, :vsoe_permit_discount, :vsoe_price
+        :vsoe_delivered, :vsoe_permit_discount, :vsoe_price, :create_wo
 
       field :custom_field_list, CustomFieldList
 

--- a/spec/netsuite/records/invoice_item_spec.rb
+++ b/spec/netsuite/records/invoice_item_spec.rb
@@ -11,7 +11,7 @@ describe NetSuite::Records::InvoiceItem do
       :options, :order_line, :percent_complete, :quantity, :quantity_available, :quantity_fulfilled, :quantity_on_hand,
       :quantity_ordered, :quantity_remaining, :rate, :rev_rec_end_date, :rev_rec_start_date, :serial_numbers, :ship_group,
       :tax1_amt, :tax_rate1, :tax_rate2, :vsoe_allocation, :vsoe_amount, :vsoe_deferral, :vsoe_delivered, :vsoe_permit_discount,
-      :vsoe_price
+      :vsoe_price, :create_wo
     ].each do |field|
       expect(item).to have_field(field)
     end


### PR DESCRIPTION
### Issue Faced:

There was a requirement from our consumer to add a createWo field in the inventory item.

While debugging further, it has been observed that create_wo is not part of the supported field list.

### Solution:
- Added create_wo field in Inventory Item
- Added field in specs to verify the presence of field