### PR TITLE
Purchase Order ship_to should be a record_ref

### DIFF
--- a/lib/netsuite/records/purchase_order.rb
+++ b/lib/netsuite/records/purchase_order.rb
@@ -12,7 +12,7 @@ module NetSuite
       fields :created_date, :currency_name, :due_date, :email, :exchange_rate,
              :fax, :fob, :interco_status, :interco_transaction, :last_modified_date,
              :linked_tracking_numbers, :memo, :message, :other_ref_num, :ship_date,
-             :ship_is_residential, :ship_to, :source, :status, :sub_total, :supervisor_approval,
+             :ship_is_residential, :source, :status, :sub_total, :supervisor_approval,
              :tax2_total, :tax_total, :to_be_emailed, :to_be_faxed, :to_be_printed,
              :total, :tracking_numbers, :tran_date, :tran_id, :vat_reg_num
 
@@ -27,7 +27,8 @@ module NetSuite
 
       record_refs :approval_status, :bill_address_list, :klass, :created_from, :currency,
                   :custom_form, :department, :employee, :entity, :location, :next_approver,
-                  :order_status, :purchase_contract, :ship_method, :subsidiary, :terms
+                  :order_status, :purchase_contract, :ship_method, :ship_to, :subsidiary,
+                  :terms
 
       attr_reader :internal_id
       attr_accessor :external_id


### PR DESCRIPTION
Per the NetSuite schema browser the Purchase Order shipping_to should be a record_ref, since at least API version 2014_1.