### PR TITLE
Accept write_timeout configuration, and supply it along to savoy

### DIFF
--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -24,6 +24,7 @@ module NetSuite
         endpoint: endpoint,
         read_timeout: read_timeout,
         open_timeout: open_timeout,
+        write_timeout: write_timeout,
         namespaces: namespaces,
         soap_header: auth_header(credentials).update(soap_header).merge(soap_header_extra_info),
         pretty_print_xml: true,
@@ -362,6 +363,18 @@ module NetSuite
         self.open_timeout = timeout
       else
         attributes[:open_timeout]
+      end
+    end
+
+    def write_timeout=(timeout)
+      attributes[:write_timeout] = timeout
+    end
+
+    def write_timeout(timeout = nil)
+      if timeout
+        self.write_timeout = timeout
+      else
+        attributes[:write_timeout]
       end
     end
 

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -500,14 +500,17 @@ describe NetSuite::Configuration do
     it 'has defaults' do
       expect(config.read_timeout).to eql(60)
       expect(config.open_timeout).to be_nil
+      expect(config.write_timeout).to be_nil
     end
 
     it 'sets timeouts' do
       config.read_timeout = 100
       config.open_timeout = 60
+      config.write_timeout = 14
 
       expect(config.read_timeout).to eql(100)
       expect(config.open_timeout).to eql(60)
+      expect(config.write_timeout).to eql(14)
 
       # ensure no exception is raised
       config.connection


### PR DESCRIPTION
The default timeout for reading from netsuite in the gem's configuration is 60 seconds, and the 'open' timeout can be set, but the 'write' timeout was not settable, and defaulted to [0.25 seconds](https://www.rubydoc.info/github/httprb/http/HTTP/Timeout/PerOperation).

Allow the write-timeout to be configured, and supply it to Savoy alongside the read and open timeouts.