### PR TITLE
Add write timeout configuration (backwards compatible)

### DIFF
--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -19,7 +19,7 @@ module NetSuite
     end
 
     def connection(params={}, credentials={}, soap_header_extra_info={})
-      client = Savon.client({
+      savon_params = {
         wsdl: cached_wsdl || wsdl,
         endpoint: endpoint,
         read_timeout: read_timeout,
@@ -33,7 +33,8 @@ module NetSuite
         log_level: log_level,
         log: !silent, # turn off logging entirely if configured
         proxy: proxy,
-      }.update(params))
+      }.update(params)
+      client = Savon.client(savon_params)
       cache_wsdl(client)
       return client
     end

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -24,6 +24,7 @@ module NetSuite
         endpoint: endpoint,
         read_timeout: read_timeout,
         open_timeout: open_timeout,
+        write_timeout: write_timeout,
         namespaces: namespaces,
         soap_header: auth_header(credentials).update(soap_header).merge(soap_header_extra_info),
         pretty_print_xml: true,
@@ -362,6 +363,18 @@ module NetSuite
         self.open_timeout = timeout
       else
         attributes[:open_timeout]
+      end
+    end
+
+    def write_timeout=(timeout)
+      attributes[:write_timeout] = timeout
+    end
+
+    def write_timeout(timeout = nil)
+      if timeout
+        self.write_timeout = timeout
+      else
+        attributes[:write_timeout]
       end
     end
 

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -19,7 +19,13 @@ module NetSuite
     end
 
     def connection(params={}, credentials={}, soap_header_extra_info={})
-      savon_params = {
+      client = Savon.client(savon_params(params, credentials, soap_header_extra_info))
+      cache_wsdl(client)
+      client
+    end
+
+    def savon_params(params={}, credentials={}, soap_header_extra_info={})
+      {
         wsdl: cached_wsdl || wsdl,
         endpoint: endpoint,
         read_timeout: read_timeout,
@@ -34,9 +40,6 @@ module NetSuite
         log: !silent, # turn off logging entirely if configured
         proxy: proxy,
       }.update(params)
-      client = Savon.client(savon_params)
-      cache_wsdl(client)
-      return client
     end
 
     def filters(list = nil)

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -25,12 +25,11 @@ module NetSuite
     end
 
     def savon_params(params={}, credentials={}, soap_header_extra_info={})
-      {
+      full_params = {
         wsdl: cached_wsdl || wsdl,
         endpoint: endpoint,
         read_timeout: read_timeout,
         open_timeout: open_timeout,
-        write_timeout: write_timeout,
         namespaces: namespaces,
         soap_header: auth_header(credentials).update(soap_header).merge(soap_header_extra_info),
         pretty_print_xml: true,
@@ -39,8 +38,12 @@ module NetSuite
         log_level: log_level,
         log: !silent, # turn off logging entirely if configured
         proxy: proxy,
-      }.update(params)
+      }
+      full_params.update(params)
+      full_params.update(write_timeout: write_timeout) if supports_write_timeout?
+      full_params
     end
+
 
     def filters(list = nil)
       if list
@@ -371,11 +374,13 @@ module NetSuite
     end
 
     def write_timeout=(timeout)
+      write_timeout_not_supported! unless supports_write_timeout?
       attributes[:write_timeout] = timeout
     end
 
     def write_timeout(timeout = nil)
       if timeout
+        write_timeout_not_supported! unless supports_write_timeout?
         self.write_timeout = timeout
       else
         attributes[:write_timeout]
@@ -443,6 +448,16 @@ module NetSuite
 
     def multi_tenant?
       @multi_tenant
+    end
+
+    private
+
+    def supports_write_timeout?
+      Savon::VERSION >= "2.13.0"
+    end
+
+    def write_timeout_not_supported!
+      fail(ConfigurationError, "Savon doesn't support write_timeout until version 2.13.0")
     end
   end
 end

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -594,9 +594,6 @@ describe NetSuite::Configuration do
         expect(config.read_timeout).to eql(100)
         expect(config.open_timeout).to eql(60)
         expect(config.write_timeout).to eql(14)
-
-        # ensure no exception is raised
-        config.connection
       end
     end
 
@@ -616,9 +613,6 @@ describe NetSuite::Configuration do
 
         expect(config.read_timeout).to eql(100)
         expect(config.open_timeout).to eql(60)
-
-        # ensure no exception is raised
-        config.connection
       end
     end
   end

--- a/spec/netsuite/configuration_spec.rb
+++ b/spec/netsuite/configuration_spec.rb
@@ -500,14 +500,17 @@ describe NetSuite::Configuration do
     it 'has defaults' do
       expect(config.read_timeout).to eql(60)
       expect(config.open_timeout).to be_nil
+      expect(config.write_timeout).to be_nil
     end
 
     it 'sets timeouts' do
       config.read_timeout = 100
       config.open_timeout = 60
+      config.write_timeout = 14
 
       expect(config.read_timeout).to eql(100)
       expect(config.open_timeout).to eql(60)
+      expect(config.write_timeout).to eql(14)
 
       # ensure no exception is raised
       config.connection


### PR DESCRIPTION
> The default timeout for reading from netsuite in the gem's configuration is 60 seconds, and the 'open' timeout can be set, but the 'write' timeout was not settable, and defaulted to [0.25 seconds](https://www.rubydoc.info/github/httprb/http/HTTP/Timeout/PerOperation).
> 
> Allow the write-timeout to be configured, and supply it to Savoy alongside the read and open timeouts.

(revert-revert from #587)

But this time, include a version-check - if Savon is below version 2.13.0, it doesn't accept `write_timeout`, and we should also complain (`NetSuite::ConfigurationError` if someone tries to set that option on _this_ gem). And I enabled CI on my fork, instead of running tests locally - I hadn't realized how much of a matrix you were testing against, sorry about that!

The `Configuration#connection` method got unwieldy during that process (and was a bit undertested), so I extracted `Configuration#savon_params` as a method, tested it directly, and included contexts exercising the cases when `Savon::VERSION` was just before and just after the `write_timeout` feature was added.