### PR TITLE
Add department and location to CashRefundItem/record_refs

### DIFF
--- a/lib/netsuite/records/cash_refund_item.rb
+++ b/lib/netsuite/records/cash_refund_item.rb
@@ -9,7 +9,11 @@ module NetSuite
       fields :amount, :gross_amt, :rate, :quantity, :is_taxable, :order_line, :line, :description
       field :custom_field_list,    CustomFieldList
 
-      record_refs :item, :klass, :price
+      record_refs :department,
+        :item,
+        :klass,
+        :location,
+        :price
 
       def initialize(attributes_or_record = {})
         initialize_from_attributes_hash(attributes_or_record)

--- a/spec/netsuite/records/cash_refund_item_spec.rb
+++ b/spec/netsuite/records/cash_refund_item_spec.rb
@@ -13,7 +13,11 @@ describe NetSuite::Records::CashRefundItem do
 
   it 'has all the right record refs' do
     [
-      :item, :klass
+      :department,
+      :item,
+      :klass,
+      :location,
+      :price
     ].each do |record_ref|
       expect(item).to have_record_ref(record_ref)
     end


### PR DESCRIPTION
Add 2 missing recordRefs to CashRefundItem class.

<img width="917" alt="Screenshot 2023-09-07 at 9 18 15 AM" src="https://github.com/NetSweet/netsuite/assets/1721928/88de2683-2b6b-48b7-b5d1-495a058a8c7d">

https://www.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2020_1/schema/other/cashrefunditem.html?mode=package