### PR TITLE
Add support to Inventory Status field

### DIFF
--- a/lib/netsuite/records/inventory_assignment.rb
+++ b/lib/netsuite/records/inventory_assignment.rb
@@ -6,10 +6,10 @@ module NetSuite
       include Support::Fields
       include Namespaces::PlatformCommon
 
-      fields :date_time, :quantity, :quantity_available, :expiration_date, 
+      fields :date_time, :quantity, :quantity_available, :expiration_date,
         :receipt_inventory_number
 
-      record_refs :bin_number, :issue_inventory_number, :to_bin_number
+      record_refs :bin_number, :issue_inventory_number, :to_bin_number, :inventory_status
 
       attr_reader   :internal_id
       attr_accessor :external_id

--- a/spec/netsuite/records/inventory_assignment_spec.rb
+++ b/spec/netsuite/records/inventory_assignment_spec.rb
@@ -13,7 +13,7 @@ describe NetSuite::Records::InventoryAssignment do
 
   it 'has all the right record refs' do
     [
-      :bin_number, :issue_inventory_number, :to_bin_number
+      :bin_number, :issue_inventory_number, :to_bin_number, :inventory_status
     ].each do |record_ref|
       expect(item).to have_record_ref(record_ref)
     end


### PR DESCRIPTION
The `inventoryStatus` field under of the `InventoryAssignment` is currently unsupported by the gem.
<img width="709" alt="13-33-d54a7-rk2r7" src="https://github.com/NetSweet/netsuite/assets/24601519/585b4d1e-b888-4063-9fff-b67cc47eab20">

This should be added to support NetSuite accounts using Inventory Status in the inventory detail subrecord
<img width="478" alt="13-35-3945u-ep3sd" src="https://github.com/NetSweet/netsuite/assets/24601519/b9727ab8-7f0e-4e54-ab5a-c587f60826e1">


