### PR TITLE
Customer Deposit - Move klass from fields to record_refs

### DIFF
--- a/lib/netsuite/records/customer_deposit.rb
+++ b/lib/netsuite/records/customer_deposit.rb
@@ -13,7 +13,7 @@ module NetSuite
       actions :get, :get_list, :initialize, :add, :delete, :update, :upsert, :search
 
       fields :created_date, :last_modified_date, :status, :payment, :tran_date, :exchange_rate, :undep_funds, :memo,
-             :check_num, :klass, :currency_name, :is_recurring_payment, :tran_id, :auth_code,
+             :check_num, :currency_name, :is_recurring_payment, :tran_id, :auth_code,
              :cc_approved, :cc_avs_street_match, :cc_avs_zip_match, :cc_expire_date, :cc_is_purchase_card_bin, :cc_name, :cc_number,
              :cc_process_as_purchase_card, :cc_security_code, :cc_security_code_match, :cc_street, :cc_zip_code, :charge_it
 
@@ -23,7 +23,7 @@ module NetSuite
 
       record_refs :customer, :sales_order, :account, :department,
         :payment_method, :payment_option, :custom_form, :currency,
-        :posting_period, :subsidiary, :location,
+        :posting_period, :subsidiary, :location, :klass
         # only available in an advanced search result
         :deposit_transaction
 


### PR DESCRIPTION
`:klass` is included under fields. This doesn't allow us to correctly reference the record reference of the Class records in NetSuite.