### PR TITLE
Remove dependence on `Object#blank?` monkey patch

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 * Revert recent proxy changes which breaks proxy usage by @andrewdicken-stripe in https://github.com/NetSweet/netsuite/pull/579
+* Fix incompatibility with Nori v2.7+ after it removed `Object#blank?` monkey patch (#607)
 
 ### Breaking Changes
 

--- a/lib/netsuite/actions/delete_list.rb
+++ b/lib/netsuite/actions/delete_list.rb
@@ -53,7 +53,7 @@ module NetSuite
       end
 
       def success?
-        @success ||= response_errors.blank?
+        @success ||= (response_errors.nil? || response_errors.empty?)
       end
 
       def response_errors

--- a/lib/netsuite/configuration.rb
+++ b/lib/netsuite/configuration.rb
@@ -202,7 +202,7 @@ module NetSuite
     end
 
     def auth_header(credentials={})
-      if !credentials[:consumer_key].blank? || !consumer_key.blank?
+      if !credentials[:consumer_key].to_s.empty? || !consumer_key.to_s.empty?
         token_auth(credentials)
       else
         user_auth(credentials)

--- a/spec/netsuite/actions/delete_list_spec.rb
+++ b/spec/netsuite/actions/delete_list_spec.rb
@@ -76,6 +76,9 @@ describe NetSuite::Actions::DeleteList do
 
       it 'constructs error objects' do
         response = NetSuite::Actions::DeleteList.call([klass, :list => customer_list_with_error])
+
+        expect(response).to_not be_success
+
         expect(response.errors.keys).to match_array(customer_with_error.internal_id)
         expect(response.errors[customer_with_error.internal_id].first.code).to eq('USER_EXCEPTION')
         expect(response.errors[customer_with_error.internal_id].first.message).to eq('Invalid record: type=event,id=100015,scompid=TSTDRV96')


### PR DESCRIPTION
Nori patched `Object` to implement a `blank?` method, however it was removed in v2.7 (February 2024), so uses within this gem were now breaking without the method being implemented.

Nori commit:
https://github.com/savonrb/nori/commit/780d01d6da13e69d205217f2418ddd67a20a5355

CI was passing for Ruby < 3, since Nori v2.7 requires Ruby 3, however Ruby >= 3 was failing once it started using Nori v2.7.