### PR TITLE
Handle single result in get_item_availability

### DIFF
--- a/lib/netsuite/records/item_availability.rb
+++ b/lib/netsuite/records/item_availability.rb
@@ -30,9 +30,12 @@ module NetSuite
           return false
         end
         if result[:item_availability_list]
-          result[:item_availability_list][:item_availability].map do |row|
-            NetSuite::Records::ItemAvailability.new(row)
+          rows = result[:item_availability_list][:item_availability]
+          unless rows.respond_to?(:to_ary)
+            rows = [rows]
           end
+
+          rows.map{|row| NetSuite::Records::ItemAvailability.new(row) }
         else
           []
         end

--- a/spec/netsuite/records/item_availability_spec.rb
+++ b/spec/netsuite/records/item_availability_spec.rb
@@ -32,28 +32,46 @@ describe NetSuite::Records::ItemAvailability do
     }
     let(:result) { NetSuite::Records::ItemAvailability.get_item_availability(inventory_item_ref_list) }
 
-    before do
-      savon.expects(:get_item_availability).with(:message => {
-        "platformMsgs:itemAvailabilityFilter" => {
-          "platformCore:item"=>{"platformCore:recordRef"=>[{:@internalId=>57}]}
-        }
-      }).returns(File.read('spec/support/fixtures/get_item_availability/get_item_availability.xml'))
+    context 'with two results' do
+      before do
+        savon.expects(:get_item_availability).with(:message => {
+          "platformMsgs:itemAvailabilityFilter" => {
+            "platformCore:item"=>{"platformCore:recordRef"=>[{:@internalId=>57}]}
+          }
+        }).returns(File.read('spec/support/fixtures/get_item_availability/get_item_availability.xml'))
+      end
+
+      it 'returns ItemAvailability records' do
+        expect(result).to be_kind_of(Array)
+        expect(result).not_to be_empty
+        expect(result[0]).to be_kind_of(NetSuite::Records::ItemAvailability)
+        expect(result[0]).to have_attributes(
+          item: be_kind_of(NetSuite::Records::InventoryItem),
+          location_id: NetSuite::Records::Location,
+          quantity_on_hand: '264.0',
+          on_hand_value_mli: '129.36',
+          reorder_point: '50.0',
+          quantity_on_order: '0.0',
+          quantity_committed: '0.0',
+          quantity_available: '264.0',
+        )
+      end
     end
 
-    it 'returns ItemAvailability records' do
-      expect(result).to be_kind_of(Array)
-      expect(result).not_to be_empty
-      expect(result[0]).to be_kind_of(NetSuite::Records::ItemAvailability)
-      expect(result[0]).to have_attributes(
-        item: be_kind_of(NetSuite::Records::InventoryItem),
-        location_id: NetSuite::Records::Location,
-        quantity_on_hand: '264.0',
-        on_hand_value_mli: '129.36',
-        reorder_point: '50.0',
-        quantity_on_order: '0.0',
-        quantity_committed: '0.0',
-        quantity_available: '264.0',
-      )
+    context 'single result' do
+      before do
+        savon.expects(:get_item_availability).with(:message => {
+          "platformMsgs:itemAvailabilityFilter" => {
+            "platformCore:item"=>{"platformCore:recordRef"=>[{:@internalId=>57}]}
+          }
+        }).returns(File.read('spec/support/fixtures/get_item_availability/get_item_availability_single_result.xml'))
+      end
+
+      it 'returns ItemAvailability records' do
+        expect(result).to be_kind_of(Array)
+        expect(result.length).to eq(1)
+        expect(result[0]).to be_kind_of(NetSuite::Records::ItemAvailability)
+      end
     end
   end
 end

--- a/spec/support/fixtures/get_item_availability/get_item_availability_single_result.xml
+++ b/spec/support/fixtures/get_item_availability/get_item_availability_single_result.xml
@@ -1,0 +1,31 @@
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soapenv:Header>
+    <platformMsgs:documentInfo xmlns:platformMsgs="urn:messages_2016_2.platform.webservices.netsuite.com">
+      <platformMsgs:nsId>WEBSERVICES_3868171_122020162073815481885806769_24761121647f</platformMsgs:nsId>
+    </platformMsgs:documentInfo>
+  </soapenv:Header>
+  <soapenv:Body>
+    <getItemAvailabilityResponse xmlns="urn:messages_2016_2.platform.webservices.netsuite.com">
+      <platformCore:getItemAvailabilityResult xmlns:platformCore="urn:core_2016_2.platform.webservices.netsuite.com">
+        <platformCore:status isSuccess="true"/>
+        <platformCore:itemAvailabilityList>
+          <platformCore:itemAvailability>
+            <platformCore:item internalId="57" type="inventoryItem">
+              <platformCore:name>CD-R</platformCore:name>
+            </platformCore:item>
+            <platformCore:lastQtyAvailableChange>2020-04-27T08:38:20.000-07:00</platformCore:lastQtyAvailableChange>
+            <platformCore:locationId internalId="2" type="location">
+              <platformCore:name>Warehouse - West Coast</platformCore:name>
+            </platformCore:locationId>
+            <platformCore:quantityOnHand>-1.0</platformCore:quantityOnHand>
+            <platformCore:onHandValueMli>0.0</platformCore:onHandValueMli>
+            <platformCore:reorderPoint>50.0</platformCore:reorderPoint>
+            <platformCore:quantityOnOrder>0.0</platformCore:quantityOnOrder>
+            <platformCore:quantityCommitted>0.0</platformCore:quantityCommitted>
+            <platformCore:quantityAvailable>0.0</platformCore:quantityAvailable>
+          </platformCore:itemAvailability>
+        </platformCore:itemAvailabilityList>
+      </platformCore:getItemAvailabilityResult>
+    </getItemAvailabilityResponse>
+  </soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
When get_item_availability returns single result, Savon doesn't wrap it in an array. This PR handles such response.