### PR TITLE
Add Custom Field List to Assembly Build Class

### DIFF
--- a/lib/netsuite/records/assembly_build.rb
+++ b/lib/netsuite/records/assembly_build.rb
@@ -5,7 +5,6 @@ module NetSuite
       include Support::RecordRefs
       include Support::Actions
       include Support::Records
-	  include Support::Fields
       include Namespaces::TranInvt
 
       actions :get, :add, :initialize, :delete, :update, :upsert, :upsert_list,
@@ -22,6 +21,7 @@ module NetSuite
         :subsidiary, :units
 
       field :component_list,        AssemblyComponentList
+      field :custom_field_list,     CustomFieldList
       field :inventory_detail,      InventoryDetail
 
 


### PR DESCRIPTION
The `AssemblyBuild` schema supports `customFieldList` as documented in the schema browser [here](https://www.netsuite.com/help/helpcenter/en_US/srbrowser/Browser2018_1/schema/record/assemblybuild.html). This PR simply adds a `field :custom_field_list` call to the `AssemblyBuild` class. This enables the `customFieldList` field on `AssemblyBuild` to be accessed via this gem with no further changes necessary. Also removed a duplicate include.